### PR TITLE
WIP: Add the RARE term rewriting system

### DIFF
--- a/carcara/src/ast/mod.rs
+++ b/carcara/src/ast/mod.rs
@@ -332,6 +332,9 @@ pub enum Sort {
     ///
     /// The two associated terms are the sort arguments for this sort.
     Array(Rc<Term>, Rc<Term>),
+
+    /// RARE gradual type
+    Any,
 }
 
 /// A quantifier, either `forall` or `exists`.

--- a/carcara/src/ast/printer.rs
+++ b/carcara/src/ast/printer.rs
@@ -413,6 +413,7 @@ impl fmt::Display for Sort {
             Sort::Real => write!(f, "Real"),
             Sort::String => write!(f, "String"),
             Sort::Array(x, y) => write_s_expr(f, "Array", &[x, y]),
+            Sort::Any => write!(f, "?"),
         }
     }
 }

--- a/carcara/src/lib.rs
+++ b/carcara/src/lib.rs
@@ -39,6 +39,7 @@ pub mod ast;
 pub mod benchmarking;
 pub mod checker;
 pub mod parser;
+pub mod rare;
 mod utils;
 
 use checker::error::CheckerError;

--- a/carcara/src/parser/lexer.rs
+++ b/carcara/src/parser/lexer.rs
@@ -101,6 +101,15 @@ pub enum Reserved {
 
     /// The `set-logic` reserved word.
     SetLogic,
+
+    /// RARE `define-rule` reserved word.
+    DefineRule,
+
+    /// RARE `define-cond-rule` reserved word.
+    DefineCondRule,
+
+    /// RARE `define-rule*` reserved word.
+    DefineRecRule,
 }
 
 impl_str_conversion_traits!(Reserved {
@@ -123,6 +132,9 @@ impl_str_conversion_traits!(Reserved {
     DefineFun: "define-fun",
     Assert: "assert",
     SetLogic: "set-logic",
+    DefineCondRule: "define-cond-rule",
+    DefineRule: "define-rule",
+    DefineRecRule: "define-rule*",
 });
 
 /// Represents a position (line and column numbers) in the source input.

--- a/carcara/src/rare/mod.rs
+++ b/carcara/src/rare/mod.rs
@@ -1,0 +1,43 @@
+use std::fmt::Debug;
+
+use crate::ast::*;
+
+pub struct RewritingRules(pub Vec<RewriteRule>);
+
+impl Debug for RewritingRules {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct RewriteRule {
+    pub id: String,
+    pub is_rec: bool,
+    pub params: Vec<Parameter>,
+    pub cond: Option<Rc<Term>>,
+    pub match_expr: Rc<Term>,
+    pub target_expr: Rc<Term>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Parameter {
+    pub id: String,
+    pub sort: Rc<Term>,
+    pub attrs: Vec<Attribute>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Attribute {
+    List,
+}
+
+impl From<String> for Attribute {
+    // Required method
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "list" => Attribute::List,
+            s => unimplemented!("attribute {}", s),
+        }
+    }
+}


### PR DESCRIPTION
This PR tracks the progress of adding support to the RARE term rewriting system. This feature will allow the reconstruction of fine-grained Proofs of Rewrites More information on the RARE TRS could be find [here](https://hanielbarbosa.com/papers/fmcad2022.pdf).

Remaining tasks:
- [x] Parse RARE rule
- [ ] Implement the type checker and support Gradual type
- [ ] Implement the algorithm for reconstructing a proof sketch
- [ ] Add RARE procedure in [simplification.rs](https://github.com/ufmg-smite/carcara/blob/main/carcara/src/checker/rules/simplification.rs)


