### PR TITLE
[rules] [strings] Adds the `concat_conflict` rule and unit tests

### DIFF
--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -99,6 +99,9 @@ pub enum CheckerError {
     #[error("expected term '{0}' to be a boolean constant")]
     ExpectedAnyBoolConstant(Rc<Term>),
 
+    #[error("expected term '{0}' to be a 'str.++' application")]
+    ExpectedConcatApplication(Rc<Term>),
+
     #[error("expected term '{1}' to be numerical constant {:?}", .0.to_f64())]
     ExpectedNumber(Rational, Rc<Term>),
 

--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -99,8 +99,11 @@ pub enum CheckerError {
     #[error("expected term '{0}' to be a boolean constant")]
     ExpectedAnyBoolConstant(Rc<Term>),
 
-    #[error("expected term '{0}' to be a 'str.++' application")]
-    ExpectedConcatApplication(Rc<Term>),
+    #[error("expected term '{0}' to be a string constant of length one")]
+    ExpectedStringConstantOfLengthOne(Rc<Term>),
+
+    #[error("expected terms '{0}' and '{1}' to have different constant prefixes")]
+    ExpectedDifferentConstantPrefixes(Rc<Term>, Rc<Term>),
 
     #[error("expected term '{1}' to be numerical constant {:?}", .0.to_f64())]
     ExpectedNumber(Rational, Rc<Term>),

--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -561,6 +561,7 @@ impl<'c> ProofChecker<'c> {
 
             "concat_eq" => strings::concat_eq,
             "concat_unify" => strings::concat_unify,
+            "concat_conflict" => strings::concat_conflict,
 
             // Special rules that always check as valid, and are used to indicate holes in the
             // proof.


### PR DESCRIPTION
This PR adds the `concat_conflict` rule from the Strings theory.

Rule reference can be found in the [cvc5 documentation](https://cvc5.github.io/docs-ci/docs-main/proofs/proof_rules.html#_CPPv4N4cvc59ProofRule15CONCAT_CONFLICTE) and in the [AletheLF specification](https://github.com/cvc5/cvc5/blob/3d249fa410d350d418e68f893fe175f80ab9ce10/proofs/alf/cvc5/rules/Strings.smt3#L67-L94).