### PR TITLE
[rules] [strings] Add support for `concat_csplit` rule

### DIFF
--- a/carcara/src/ast/macros.rs
+++ b/carcara/src/ast/macros.rs
@@ -168,7 +168,8 @@ macro_rules! match_term {
     (@GET_VARIANT sign_extend) => { $crate::ast::ParamOperator::SignExtend };
 
     (@GET_VARIANT strconcat) => { $crate::ast::Operator::StrConcat };
-    (@GET_VARIANT strlen) => { $crate::ast::Operator::StrLen };
+    (@GET_VARIANT strsubstr) => { $crate::ast::Operator::Substring };
+    (@GET_VARIANT strlen)    => { $crate::ast::Operator::StrLen };
 }
 
 /// A variant of `match_term` that returns a `Result<_, CheckerError>` instead of an `Option`.

--- a/carcara/src/ast/mod.rs
+++ b/carcara/src/ast/mod.rs
@@ -965,6 +965,12 @@ impl Rc<Term> {
             .ok_or_else(|| CheckerError::ExpectedAnyNumber(self.clone()))
     }
 
+    /// Similar to `Term::as_integer`, but returns a `CheckerError` on failure.
+    pub fn as_integer_err(&self) -> Result<Integer, CheckerError> {
+        self.as_integer()
+            .ok_or_else(|| CheckerError::ExpectedAnyInteger(self.clone()))
+    }
+
     /// Similar to `Term::as_signed_number`, but returns a `CheckerError` on failure.
     pub fn as_signed_number_err(&self) -> Result<Rational, CheckerError> {
         self.as_signed_number()

--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -3,7 +3,7 @@ use crate::{
     checker::rules::linear_arithmetic::LinearComb,
     utils::{Range, TypeName},
 };
-use rug::Rational;
+use rug::{Integer, Rational};
 use std::{fmt, io};
 use thiserror::Error;
 
@@ -108,11 +108,14 @@ pub enum CheckerError {
     #[error("expected term '{1}' to be numerical constant {:?}", .0.to_f64())]
     ExpectedNumber(Rational, Rc<Term>),
 
+    #[error("expected term '{1}' to be integer constant {:?}", .0.to_i32())]
+    ExpectedInteger(Integer, Rc<Term>),
+
     #[error("expected term '{0}' to be a numerical constant")]
     ExpectedAnyNumber(Rc<Term>),
 
     #[error("expected term '{0}' to be an integer constant")]
-    ExpectedInteger(Rc<Term>),
+    ExpectedAnyInteger(Rc<Term>),
 
     #[error("expected operation term, got '{0}'")]
     ExpectedOperationTerm(Rc<Term>),

--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -562,6 +562,7 @@ impl<'c> ProofChecker<'c> {
             "concat_eq" => strings::concat_eq,
             "concat_unify" => strings::concat_unify,
             "concat_conflict" => strings::concat_conflict,
+            "concat_csplit" => strings::concat_csplit,
 
             // Special rules that always check as valid, and are used to indicate holes in the
             // proof.

--- a/carcara/src/checker/rules/extras.rs
+++ b/carcara/src/checker/rules/extras.rs
@@ -185,7 +185,7 @@ pub fn mod_simplify(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     let [a, b] = [t1, t2].map(|term| {
         let value = term.as_signed_number_err()?;
         if !value.is_integer() {
-            return Err(CheckerError::ExpectedInteger(term.clone()));
+            return Err(CheckerError::ExpectedAnyInteger(term.clone()));
         }
         Ok(value.into_numer_denom().0)
     });


### PR DESCRIPTION
This PR adds the `concat_csplit` rule from the Strings theory.

Rule reference can be found in the [cvc5 documentation](https://cvc5.github.io/docs-ci/docs-main/proofs/proof_rules.html#_CPPv4N4cvc59ProofRule13CONCAT_CSPLITE) and in the [AletheLF specification](https://github.com/cvc5/cvc5/blob/3d249fa410d350d418e68f893fe175f80ab9ce10/proofs/alf/cvc5/rules/Strings.smt3#L48-L65).