### PR TITLE
[rules] [strings] Add support for `concat_split` rule and splitted rules in prefix and suffix version

### DIFF
--- a/carcara/src/ast/macros.rs
+++ b/carcara/src/ast/macros.rs
@@ -74,6 +74,14 @@ macro_rules! match_term {
     (false = $var:expr $(, $flag:ident)?) => {
         if $var.is_bool_false() { Some(()) } else { None }
     };
+    (0 = $var:expr $(, $flag:ident)?) => {
+        if let Some(i) = $var.as_integer() {
+            if i == 0 { Some(()) } else { None }
+        } else { None }
+    };
+    ("" = $var:expr $(, $flag:ident)?) => {
+        if $var.is_empty_string() { Some(()) } else { None }
+    };
     ((forall ... $args:tt) = $var:expr) => {
         if let $crate::ast::Term::Binder($crate::ast::Binder::Forall, bindings, inner) =
             &$var as &$crate::ast::Term

--- a/carcara/src/ast/mod.rs
+++ b/carcara/src/ast/mod.rs
@@ -754,6 +754,14 @@ impl Term {
         pool.sort(&added).as_sort().unwrap().clone()
     }
 
+    /// Returns `true` if the term is the empty String.
+    pub fn is_empty_string(&self) -> bool {
+        match self {
+            Term::Const(Constant::String(s)) => s.is_empty(),
+            _ => false,
+        }
+    }
+
     /// Returns `true` if the term is an integer or real constant.
     pub fn is_number(&self) -> bool {
         matches!(self, Term::Const(Constant::Real(_) | Constant::Integer(_)))

--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -138,6 +138,9 @@ pub enum CheckerError {
     #[error("expected term {0} to be a prefix of {1}")]
     ExpectedToBePrefix(Rc<Term>, Rc<Term>),
 
+    #[error("expected term {0} to be a suffix of {1}")]
+    ExpectedToBeSuffix(Rc<Term>, Rc<Term>),
+
     #[error("this rule can only be used in the last step of a subproof")]
     MustBeLastStepInSubproof,
 

--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -563,6 +563,8 @@ impl<'c> ProofChecker<'c> {
             "concat_unify" => strings::concat_unify,
             "concat_conflict" => strings::concat_conflict,
             "concat_csplit" => strings::concat_csplit,
+            "concat_split_prefix" => strings::concat_split_prefix,
+            "concat_split_suffix" => strings::concat_split_suffix,
 
             // Special rules that always check as valid, and are used to indicate holes in the
             // proof.

--- a/carcara/src/checker/rules/strings.rs
+++ b/carcara/src/checker/rules/strings.rs
@@ -810,74 +810,74 @@ mod tests {
             "Simple working examples" {
                 r#"(assume h1 (= (str.++ "a" "b" b) (str.++ "a" c)))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: true,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: true,
                 r#"(assume h1 (= (str.++ a "b" c) (str.++ "ab" c)))
                    (assume h2 (not (= (str.len (str.++ a "b")) 0)))
-                   (step t1 (cl (= (str.++ a "b") (str.++ "a" (str.substr (str.++ a "b") 0 (- (str.len (str.++ a "b")) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: true,
+                   (step t1 (cl (= (str.++ a "b") (str.++ "a" (str.substr (str.++ a "b") 1 (- (str.len (str.++ a "b")) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: true,
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d))))
                    (assume h2 (not (= (str.len (str.++ d c)) 0)))
-                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: true,
+                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: true,
             }
             "Reverse argument set to true" {
                 r#"(assume h1 (= (str.++ "c" "b" a) (str.++ "a" (str.++ c "b"))))
                    (assume h2 (not (= (str.len (str.++ "b" a)) 0)))
-                   (step t1 (cl (= (str.++ "b" a) (str.++ (str.substr (str.++ "b" a) 1 (- (str.len (str.++ "b" a)) 1)) "b"))) :rule concat_csplit :premises (h1 h2) :args (true))"#: true,
+                   (step t1 (cl (= (str.++ "b" a) (str.++ (str.substr (str.++ "b" a) 0 (- (str.len (str.++ "b" a)) 1)) "b"))) :rule concat_csplit :premises (h1 h2) :args (true))"#: true,
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ "b" a))) (str.++ "b" (str.++ "c" "de"))))
                    (assume h2 (not (= (str.len (str.++ c (str.++ "b" a))) 0)))
-                   (step t1 (cl (= (str.++ c (str.++ "b" a)) (str.++ (str.substr (str.++ c (str.++ "b" a)) 1 (- (str.len (str.++ c (str.++ "b" a))) 1)) "e"))) :rule concat_csplit :premises (h1 h2) :args (true))"#: true,
+                   (step t1 (cl (= (str.++ c (str.++ "b" a)) (str.++ (str.substr (str.++ c (str.++ "b" a)) 0 (- (str.len (str.++ c (str.++ "b" a))) 1)) "e"))) :rule concat_csplit :premises (h1 h2) :args (true))"#: true,
             }
             "Term does not have a constant prefix" {
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ b (str.++ "c" d))))
                    (assume h2 (not (= (str.len (str.++ d c)) 0)))
-                   (step t1 (cl (= (str.++ d c) (str.++ b (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= (str.++ d c) (str.++ b (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
             }
             "Term are not a str.++ application" {
                 r#"(assume h1 (= (str.++ "a" "b" b) ""))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
                 r#"(assume h1 (= "" (str.++ "a" c)))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
             }
             "Invalid argument type" {
                 r#"(assume h1 (= (str.++ "a" "b" b) (str.++ "a" c)))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (1))"#: false,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (1))"#: false,
                 r#"(assume h1 (= (str.++ "a" "b" b) (str.++ "a" c)))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (1.5))"#: false,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args (1.5))"#: false,
                 r#"(assume h1 (= (str.++ "a" "b" b) (str.++ "a" c)))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args ((- 1)))"#: false,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args ((- 1)))"#: false,
                 r#"(assume h1 (= (str.++ "a" "b" b) (str.++ "a" c)))
                    (assume h2 (not (= (str.len "a") 0)))
-                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 0 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args ("test"))"#: false,
+                   (step t1 (cl (= "a" (str.++ "a" (str.substr "a" 1 (- (str.len "a") 1))))) :rule concat_csplit :premises (h1 h2) :args ("test"))"#: false,
             }
             "Premise term is not an equality" {
                 r#"(assume h1 (not (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d)))))
                    (assume h2 (not (= (str.len (str.++ d c)) 0)))
-                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
             }
             "Premise term is not an inequality of the form (not (= (str.len str) 0))" {
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d))))
                    (assume h2 (= (str.len (str.++ d c)) 0))
-                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d))))
                    (assume h2 (not (= (str.len (str.++ d c)) 1)))
-                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
             }
             "Conclusion term is not an equality" {
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d))))
                    (assume h2 (not (= (str.len (str.++ d c)) 0)))
-                   (step t1 (cl (not (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1)))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (not (= (str.++ d c) (str.++ "b" (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1)))))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
             }
             "Switched conclusion terms" {
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d))))
                    (assume h2 (not (= (str.len (str.++ d c)) 0)))
-                   (step t1 (cl (= (str.++ "b" (str.substr (str.++ d c) 0 (- (str.len (str.++ d c)) 1))) (str.++ d c))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
+                   (step t1 (cl (= (str.++ "b" (str.substr (str.++ d c) 1 (- (str.len (str.++ d c)) 1))) (str.++ d c))) :rule concat_csplit :premises (h1 h2) :args (false))"#: false,
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ "b" a))) (str.++ "b" (str.++ "c" "de"))))
                    (assume h2 (not (= (str.len (str.++ c (str.++ "b" a))) 0)))
-                   (step t1 (cl (= (str.++ (str.substr (str.++ c (str.++ "b" a)) 1 (- (str.len (str.++ c (str.++ "b" a))) 1)) "e") (str.++ c (str.++ "b" a)))) :rule concat_csplit :premises (h1 h2) :args (true))"#: false,
+                   (step t1 (cl (= (str.++ (str.substr (str.++ c (str.++ "b" a)) 0 (- (str.len (str.++ c (str.++ "b" a))) 1)) "e") (str.++ c (str.++ "b" a)))) :rule concat_csplit :premises (h1 h2) :args (true))"#: false,
             }
             "Inverted argument value" {
                 r#"(assume h1 (= (str.++ d (str.++ c (str.++ b "a"))) (str.++ "b" (str.++ "c" d))))

--- a/carcara/src/checker/rules/strings.rs
+++ b/carcara/src/checker/rules/strings.rs
@@ -69,17 +69,13 @@ fn expand_string_constants(pool: &mut dyn TermPool, term: &Rc<Term>) -> Rc<Term>
             pool.add(Term::Binder(*q, bindings.clone(), new_inner))
         }
         Term::ParamOp { op, op_args, args } => {
-            let new_op_args = op_args
-                .iter()
-                .map(|term| expand_string_constants(pool, term))
-                .collect();
             let new_args = args
                 .iter()
                 .map(|term| expand_string_constants(pool, term))
                 .collect();
             pool.add(Term::ParamOp {
                 op: *op,
-                op_args: new_op_args,
+                op_args: op_args.clone(),
                 args: new_args,
             })
         }

--- a/carcara/src/checker/rules/strings.rs
+++ b/carcara/src/checker/rules/strings.rs
@@ -143,7 +143,11 @@ fn is_prefix_or_suffix(
         p_flat.reverse();
     }
     if p_flat.len() > t_flat.len() {
-        return Err(CheckerError::ExpectedToBePrefix(pref, term));
+        if rev {
+            return Err(CheckerError::ExpectedToBeSuffix(pref, term));
+        } else {
+            return Err(CheckerError::ExpectedToBePrefix(pref, term));
+        }
     }
     for (i, el) in p_flat.iter().enumerate() {
         assert_polyeq_expected(el, t_flat[i].clone(), polyeq_time)?;

--- a/carcara/src/checker/rules/strings.rs
+++ b/carcara/src/checker/rules/strings.rs
@@ -11,14 +11,14 @@ use std::{cmp, time::Duration};
 ///
 /// In this flat form, all `str.++` applications are dissolved and every
 /// argument of those applications is inserted into the vector (e.g., `(str.++
-/// a (str.++ b c))` would lead to `[a, b, c]`, where `a`, `b` e `c` são
+/// a (str.++ b c))` would lead to `[a, b, c]`, where `a`, `b` and `c` are
 /// arbitrary String terms). Furthermore, all String constants are broken
 /// into constants of size one and are inserted into the vector too.
 ///
 /// All String terms that aren't `str.++` applications can be seen as `(str.++ term "")`.
 /// So, applying `flatten` to them would lead to `[term]`. Furthermore,
 /// the empty String isn't mapped to any entry in the vector, so `flatten`
-/// applied to `""` lead to an empty vector.
+/// applied to `""` leads to an empty vector.
 fn flatten(pool: &mut dyn TermPool, term: Rc<Term>) -> Vec<Rc<Term>> {
     let mut flattened = Vec::new();
     if let Term::Const(Constant::String(s)) = term.as_ref() {


### PR DESCRIPTION
This PR adds the `concat_csplit` rule from the Strings theory.
Rule reference can be found in the [cvc5 documentation](https://cvc5.github.io/docs-ci/docs-main/proofs/proof_rules.html#_CPPv4N4cvc59ProofRule12CONCAT_SPLITE) and in the [AletheLF specification](https://github.com/cvc5/cvc5/blob/14eae04ec806140aa8e92293b69b2ca7a251d895/proofs/alf/cvc5/rules/Strings.smt3#L68-L95).

Furthermore, it:
* Splits the rule into two versions: application over prefixes and over suffixes;
* Makes the necessary modifications to allow other rules to be split in this way;
* Standardizes variable names to how they appear in AletheLF documentation;
* Fixes a bug in the function that creates Skolems in the `concat_csplit` rule.