### PR TITLE
[rules] [strings] Splits `concat_csplit` rule into prefix and suffix versions

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -562,7 +562,8 @@ impl<'c> ProofChecker<'c> {
             "concat_eq" => strings::concat_eq,
             "concat_unify" => strings::concat_unify,
             "concat_conflict" => strings::concat_conflict,
-            "concat_csplit" => strings::concat_csplit,
+            "concat_csplit_prefix" => strings::concat_csplit_prefix,
+            "concat_csplit_suffix" => strings::concat_csplit_suffix,
             "concat_split_prefix" => strings::concat_split_prefix,
             "concat_split_suffix" => strings::concat_split_suffix,
 


### PR DESCRIPTION
This PR splits the `concat_csplit` rule into a prefix version and a suffix version.
The main reason for this modification is to simplify how the rule works, since it's premises and conclusion changes substantially based on the reverse parameter value (if the parameter is set to `true`, the rule is reasoning about suffixes, and if it's set to `false`, about prefixes).

All unit tests where converted and some additional cases where incorporated to cover previously untested scenarios.

The rule reference can be found in the [cvc5 documentation](https://cvc5.github.io/docs-ci/docs-main/proofs/proof_rules.html#_CPPv4N4cvc59ProofRule13CONCAT_CSPLITE) and in the [AletheLF specification](https://github.com/cvc5/cvc5/blob/231c532981c71e0b450d6bfc238c922a36233282/proofs/alf/cvc5/rules/Strings.smt3#L49-L66).