### PR TITLE
Use SortedVar rather than String for vars in anchor assingnments

### DIFF
--- a/carcara/src/ast/context.rs
+++ b/carcara/src/ast/context.rs
@@ -12,7 +12,7 @@ impl Context {
     /// `cumulative_substitution` field.
     fn build(
         pool: &mut dyn TermPool,
-        assignment_args: &[(String, Rc<Term>)],
+        assignment_args: &[(SortedVar, Rc<Term>)],
         variable_args: &[SortedVar],
     ) -> Result<Self, SubstitutionError> {
         // We build the context mappings incrementally, using the mappings already
@@ -25,7 +25,7 @@ impl Context {
         let mappings = assignment_args
             .iter()
             .map(|(var, value)| {
-                let var_term = pool.add(Term::new_var(var, pool.sort(value)));
+                let var_term = pool.add(Term::Var(var.0.clone(), var.1.clone()));
                 let new_value = substitution.apply(pool, value);
                 substitution.insert(pool, var_term.clone(), new_value.clone())?;
                 Ok((var_term, new_value))
@@ -130,7 +130,7 @@ impl ContextStack {
     pub fn push(
         &mut self,
         pool: &mut dyn TermPool,
-        assignment_args: &[(String, Rc<Term>)],
+        assignment_args: &[(SortedVar, Rc<Term>)],
         variable_args: &[SortedVar],
         context_id: usize,
     ) -> Result<(), SubstitutionError> {

--- a/carcara/src/ast/mod.rs
+++ b/carcara/src/ast/mod.rs
@@ -156,7 +156,7 @@ pub struct Subproof {
     pub commands: Vec<ProofCommand>,
 
     /// The "assignment" style arguments of the subproof, of the form `(:= <symbol> <term>)`.
-    pub assignment_args: Vec<(String, Rc<Term>)>,
+    pub assignment_args: Vec<(SortedVar, Rc<Term>)>,
 
     /// The "variable" style arguments of the subproof, of the form `(<symbol> <sort>)`.
     pub variable_args: Vec<SortedVar>,

--- a/carcara/src/ast/printer.rs
+++ b/carcara/src/ast/printer.rs
@@ -153,12 +153,14 @@ impl<'a> PrintProof for AlethePrinter<'a> {
                             is_first = false;
                             var.print_with_sharing(self)?;
                         }
-                        for (name, value) in &s.assignment_args {
+                        for (var, value) in &s.assignment_args {
                             if !is_first {
                                 write!(self.inner, " ")?;
                             }
                             is_first = false;
-                            write!(self.inner, "(:= {} ", name)?;
+                            write!(self.inner, "(:= ")?;
+                            var.print_with_sharing(self)?;
+                            write!(self.inner, " ")?;
                             value.print_with_sharing(self)?;
                             write!(self.inner, ")")?;
                         }

--- a/carcara/src/checker/rules/bitvectors.rs
+++ b/carcara/src/checker/rules/bitvectors.rs
@@ -76,9 +76,9 @@ pub fn add(RuleArgs { conclusion, pool, .. }: RuleArgs) -> RuleResult {
     let res_args: Vec<_> = (0..size)
         .map(|i| {
             build_term!(
-          pool,
-          (xor (xor {x[i].clone()} {y[i].clone()}) {carries[i].clone()})
-        )
+              pool,
+              (xor (xor {x[i].clone()} {y[i].clone()}) {carries[i].clone()})
+            )
         })
         .collect();
 

--- a/carcara/src/elaborator/accumulator.rs
+++ b/carcara/src/elaborator/accumulator.rs
@@ -50,7 +50,7 @@ impl Accumulator {
 
     pub fn close_subproof(
         &mut self,
-        assignment_args: Vec<(String, Rc<Term>)>,
+        assignment_args: Vec<(SortedVar, Rc<Term>)>,
         variable_args: Vec<SortedVar>,
         root_id: &str,
     ) -> ProofCommand {

--- a/carcara/src/elaborator/mod.rs
+++ b/carcara/src/elaborator/mod.rs
@@ -150,7 +150,7 @@ impl Elaborator {
     /// make sure it is the next `id` in the outer subproof.
     pub fn close_accumulator_subproof(
         &mut self,
-        assignment_args: Vec<(String, Rc<Term>)>,
+        assignment_args: Vec<(SortedVar, Rc<Term>)>,
         variable_args: Vec<SortedVar>,
         end_step: ProofStep,
         root_id: &str,

--- a/carcara/src/elaborator/polyeq.rs
+++ b/carcara/src/elaborator/polyeq.rs
@@ -94,7 +94,7 @@ impl<'a> PolyeqElaborator<'a> {
                         let assignment_args: Vec<_> = a_bindings
                             .iter()
                             .map(|x| {
-                                let var = x.0.clone();
+                                let var = (x.0.clone(), pool.sort(&x.1));
                                 let term = pool.add(x.clone().into());
                                 (var, term)
                             })
@@ -117,7 +117,7 @@ impl<'a> PolyeqElaborator<'a> {
                         let assigment_args: Vec<_> = a_bindings
                             .iter()
                             .zip(b_bindings)
-                            .map(|((a_var, _), b)| (a_var.clone(), pool.add(b.clone().into())))
+                            .map(|((a_var, a_sort), b)| ((a_var.clone(), a_sort.clone()), pool.add(b.clone().into())))
                             .collect();
 
                         let new_context_id = c.force_new_context();
@@ -338,7 +338,7 @@ impl<'a> PolyeqElaborator<'a> {
 
     fn close_subproof(
         &mut self,
-        assignment_args: Vec<(String, Rc<Term>)>,
+        assignment_args: Vec<(SortedVar, Rc<Term>)>,
         variable_args: Vec<SortedVar>,
         end_step: ProofStep,
     ) -> (usize, usize) {

--- a/carcara/src/elaborator/polyeq.rs
+++ b/carcara/src/elaborator/polyeq.rs
@@ -117,7 +117,9 @@ impl<'a> PolyeqElaborator<'a> {
                         let assigment_args: Vec<_> = a_bindings
                             .iter()
                             .zip(b_bindings)
-                            .map(|((a_var, a_sort), b)| ((a_var.clone(), a_sort.clone()), pool.add(b.clone().into())))
+                            .map(|((a_var, a_sort), b)| {
+                                ((a_var.clone(), a_sort.clone()), pool.add(b.clone().into()))
+                            })
                             .collect();
 
                         let new_context_id = c.force_new_context();

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -109,7 +109,7 @@ struct SortDef {
 /// the final AST.
 struct AnchorCommand {
     end_step_id: String,
-    assignment_args: Vec<(String, Rc<Term>)>,
+    assignment_args: Vec<(SortedVar, Rc<Term>)>,
     variable_args: Vec<SortedVar>,
 }
 
@@ -996,7 +996,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
             let args = self.parse_sequence(Parser::parse_anchor_argument, true)?;
             for a in args {
                 match a {
-                    AnchorArg::Assign(var, value) => assignment_args.push((var.clone(), value)),
+                    AnchorArg::Assign(var, value) => assignment_args.push(((var.clone(), self.pool.sort(&value)), value)),
                     AnchorArg::Variable(var) => variable_args.push(var.clone()),
                 }
             }

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -996,7 +996,9 @@ impl<'a, R: BufRead> Parser<'a, R> {
             let args = self.parse_sequence(Parser::parse_anchor_argument, true)?;
             for a in args {
                 match a {
-                    AnchorArg::Assign(var, value) => assignment_args.push(((var.clone(), self.pool.sort(&value)), value)),
+                    AnchorArg::Assign(var, value) => {
+                        assignment_args.push(((var.clone(), self.pool.sort(&value)), value))
+                    }
                     AnchorArg::Variable(var) => variable_args.push(var.clone()),
                 }
             }

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -997,7 +997,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
             for a in args {
                 match a {
                     AnchorArg::Assign(var, value) => {
-                        assignment_args.push(((var.clone(), self.pool.sort(&value)), value))
+                        assignment_args.push(((var.clone(), self.pool.sort(&value)), value));
                     }
                     AnchorArg::Variable(var) => variable_args.push(var.clone()),
                 }


### PR DESCRIPTION
This is necessary to fix a bug (introduced in
ce9d5e54099e209f74fca784d31a05b1cc1a619c) where elaborated proofs will not be checkable by Carcara itself (since the printer was not printing anchors according to the new format).