### PR TITLE
[rules] [strings] Add support for `concat_lprop` rule

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -566,6 +566,8 @@ impl<'c> ProofChecker<'c> {
             "concat_csplit_suffix" => strings::concat_csplit_suffix,
             "concat_split_prefix" => strings::concat_split_prefix,
             "concat_split_suffix" => strings::concat_split_suffix,
+            "concat_lprop_prefix" => strings::concat_lprop_prefix,
+            "concat_lprop_suffix" => strings::concat_lprop_suffix,
 
             // Special rules that always check as valid, and are used to indicate holes in the
             // proof.

--- a/carcara/src/checker/rules/strings.rs
+++ b/carcara/src/checker/rules/strings.rs
@@ -282,6 +282,8 @@ pub fn concat_eq(
     assert_num_args(args, 1)?;
     assert_clause_len(conclusion, 1)?;
 
+    match_term_err!((= x y) = &conclusion[0]);
+
     let term = get_premise_term(&premises[0])?;
     let rev = args[0].as_term()?.as_bool_err()?;
     let (s, t) = match_term_err!((= s t) = term)?;
@@ -312,6 +314,8 @@ pub fn concat_unify(
     assert_num_premises(premises, 2)?;
     assert_num_args(args, 1)?;
     assert_clause_len(conclusion, 1)?;
+
+    match_term_err!((= x y) = &conclusion[0]);
 
     let term = get_premise_term(&premises[0])?;
     let prefixes = get_premise_term(&premises[1])?;


### PR DESCRIPTION
This PR adds the `concat_lprop` rule from the Strings theory.
Rule reference can be found in the [cvc5 documentation](https://cvc5.github.io/docs-ci/docs-main/proofs/proof_rules.html#_CPPv4N4cvc59ProofRule12CONCAT_LPROPE) (at the time of writing this PR, the rule still hasn't been updated to align with its definition in AletheLF) and in the [AletheLF specification](https://github.com/cvc5/cvc5/blob/b4189cace4535142969d7eee50894e8ccb65c73c/proofs/alf/cvc5/rules/Strings.smt3#L97-L119).