### PR TITLE
[rules] [clausification, tautologies] Support for arguments

### DIFF
--- a/carcara/src/ast/term.rs
+++ b/carcara/src/ast/term.rs
@@ -815,7 +815,7 @@ impl Rc<Term> {
                 return Ok(i.to_usize().unwrap());
             }
         }
-        return Err(CheckerError::ExpectedNonnegInteger(self.clone()));
+        Err(CheckerError::ExpectedNonnegInteger(self.clone()))
     }
 
     /// Similar to `Term::as_signed_number`, but returns a `CheckerError` on failure.

--- a/carcara/src/ast/term.rs
+++ b/carcara/src/ast/term.rs
@@ -808,6 +808,16 @@ impl Rc<Term> {
             .ok_or_else(|| CheckerError::ExpectedAnyInteger(self.clone()))
     }
 
+    /// Similar to `Term::as_integer_err`, but also checks if non-negative.
+    pub fn as_usize_err(&self) -> Result<usize, CheckerError> {
+        if let Some(i) = self.as_integer() {
+            if i >= 0 {
+                return Ok(i.to_usize().unwrap());
+            }
+        }
+        return Err(CheckerError::ExpectedNonnegInteger(self.clone()));
+    }
+
     /// Similar to `Term::as_signed_number`, but returns a `CheckerError` on failure.
     pub fn as_signed_number_err(&self) -> Result<Rational, CheckerError> {
         self.as_signed_number()

--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -71,6 +71,9 @@ pub enum CheckerError {
     #[error("cannot evaluate the fixed length of the term '{0}'")]
     LengthCannotBeEvaluated(Rc<Term>),
 
+    #[error("No {0}-th child in term {1}")]
+    NoIthChildInTerm(usize, Rc<Term>),
+
     // General errors
     #[error("expected {0} premises, got {1}")]
     WrongNumberOfPremises(Range, usize),
@@ -116,6 +119,9 @@ pub enum CheckerError {
 
     #[error("expected term '{0}' to be an integer constant")]
     ExpectedAnyInteger(Rc<Term>),
+
+    #[error("expected term '{0}' to be an non-negative integer constant")]
+    ExpectedNonnegInteger(Rc<Term>),
 
     #[error("expected operation term, got '{0}'")]
     ExpectedOperationTerm(Rc<Term>),

--- a/carcara/src/checker/rules/clausification.rs
+++ b/carcara/src/checker/rules/clausification.rs
@@ -67,11 +67,13 @@ pub fn and(RuleArgs { conclusion, premises, args, .. }: RuleArgs) -> RuleResult 
 
     let and_term = get_premise_term(&premises[0])?;
     let and_contents = match_term_err!((and ...) = and_term)?;
+    let i = args[0].as_usize_err()?;
 
-    assert_eq(
-        &conclusion[0],
-        &and_contents[args[0].as_integer().unwrap().to_usize().unwrap()],
-    )
+    if i >= and_contents.len() {
+        return Err(CheckerError::NoIthChildInTerm(i, and_term.clone()));
+    }
+
+    assert_eq(&conclusion[0], &and_contents[i])
 }
 
 pub fn not_or(RuleArgs { conclusion, premises, args, .. }: RuleArgs) -> RuleResult {
@@ -82,11 +84,13 @@ pub fn not_or(RuleArgs { conclusion, premises, args, .. }: RuleArgs) -> RuleResu
     let or_term = get_premise_term(&premises[0])?;
     let or_contents = match_term_err!((not (or ...)) = or_term)?;
     let conclusion = conclusion[0].remove_negation_err()?;
+    let i = args[0].as_usize_err()?;
 
-    assert_eq(
-        conclusion,
-        &or_contents[args[0].as_integer().unwrap().to_usize().unwrap()],
-    )
+    if i >= or_contents.len() {
+        return Err(CheckerError::NoIthChildInTerm(i, or_term.clone()));
+    }
+
+    assert_eq(conclusion, &or_contents[i])
 }
 
 pub fn or(RuleArgs { conclusion, premises, .. }: RuleArgs) -> RuleResult {

--- a/carcara/src/checker/rules/tautology.rs
+++ b/carcara/src/checker/rules/tautology.rs
@@ -1,6 +1,6 @@
 use super::{
-    assert_clause_len, assert_eq, assert_num_premises, assert_polyeq, get_premise_term,
-    CheckerError, RuleArgs, RuleResult,
+    assert_clause_len, assert_eq, assert_num_args, assert_num_premises, assert_polyeq,
+    get_premise_term, CheckerError, RuleArgs, RuleResult,
 };
 use crate::{ast::*, checker::rules::assert_operation_len};
 
@@ -31,17 +31,16 @@ pub fn not_not(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     assert_eq(p, &conclusion[1])
 }
 
-pub fn and_pos(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+pub fn and_pos(RuleArgs { conclusion, args, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 2)?;
+    assert_num_args(args, 1)?;
 
     let and_contents = match_term_err!((not (and ...)) = &conclusion[0])?;
-    if !and_contents.contains(&conclusion[1]) {
-        return Err(CheckerError::TermDoesntApperInOp(
-            Operator::And,
-            conclusion[1].clone(),
-        ));
-    }
-    Ok(())
+
+    assert_eq(
+        &conclusion[1],
+        &and_contents[args[0].as_integer().unwrap().to_usize().unwrap()],
+    )
 }
 
 pub fn and_neg(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
@@ -69,18 +68,17 @@ pub fn or_pos(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     Ok(())
 }
 
-pub fn or_neg(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+pub fn or_neg(RuleArgs { conclusion, args, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 2)?;
+    assert_num_args(args, 1)?;
+
     let or_contents = match_term_err!((or ...) = &conclusion[0])?;
     let other = conclusion[1].remove_negation_err()?;
 
-    if !or_contents.contains(other) {
-        return Err(CheckerError::TermDoesntApperInOp(
-            Operator::Or,
-            other.clone(),
-        ));
-    }
-    Ok(())
+    assert_eq(
+        other,
+        &or_contents[args[0].as_integer().unwrap().to_usize().unwrap()],
+    )
 }
 
 pub fn xor_pos1(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
@@ -420,8 +418,8 @@ mod tests {
                 (declare-fun s () Bool)
             ",
             "Simple working examples" {
-                "(step t1 (cl (not (and p q r)) r) :rule and_pos)": true,
-                "(step t1 (cl (not (and (or (not r) p) q)) (or (not r) p)) :rule and_pos)": true,
+                "(step t1 (cl (not (and p q r)) r) :rule and_pos :args (2))": true,
+                "(step t1 (cl (not (and (or (not r) p) q)) (or (not r) p)) :rule and_pos :args (0))": true,
             }
             "First term in clause is not of the correct form" {
                 "(step t1 (cl (and p q r) r) :rule and_pos)": false,
@@ -502,7 +500,7 @@ mod tests {
                 (declare-fun s () Bool)
             ",
             "Simple working examples" {
-                "(step t1 (cl (or p q r) (not r)) :rule or_neg)": true,
+                "(step t1 (cl (or p q r) (not r)) :rule or_neg :args (2))": true,
             }
             "First term in clause is not of the correct form" {
                 "(step t1 (cl (and p q r) (not r)) :rule or_neg)": false,

--- a/carcara/src/checker/rules/tautology.rs
+++ b/carcara/src/checker/rules/tautology.rs
@@ -36,11 +36,13 @@ pub fn and_pos(RuleArgs { conclusion, args, .. }: RuleArgs) -> RuleResult {
     assert_num_args(args, 1)?;
 
     let and_contents = match_term_err!((not (and ...)) = &conclusion[0])?;
+    let i = args[0].as_usize_err()?;
 
-    assert_eq(
-        &conclusion[1],
-        &and_contents[args[0].as_integer().unwrap().to_usize().unwrap()],
-    )
+    if i >= and_contents.len() {
+        return Err(CheckerError::NoIthChildInTerm(i, conclusion[0].clone()));
+    }
+
+    assert_eq(&conclusion[1], &and_contents[i])
 }
 
 pub fn and_neg(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
@@ -74,11 +76,13 @@ pub fn or_neg(RuleArgs { conclusion, args, .. }: RuleArgs) -> RuleResult {
 
     let or_contents = match_term_err!((or ...) = &conclusion[0])?;
     let other = conclusion[1].remove_negation_err()?;
+    let i = args[0].as_usize_err()?;
 
-    assert_eq(
-        other,
-        &or_contents[args[0].as_integer().unwrap().to_usize().unwrap()],
-    )
+    if i >= or_contents.len() {
+        return Err(CheckerError::NoIthChildInTerm(i, conclusion[0].clone()));
+    }
+
+    assert_eq(other, &or_contents[i])
 }
 
 pub fn xor_pos1(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {


### PR DESCRIPTION
The semantics of the rules `and`, `not_or`, `and_pos`, and `or_neg` changed so that now they expect an argument as to the position in which the concluding element is from an n-ary application of the operators `and` or `or`.