### PR TITLE
Drat and Drup checking

### DIFF
--- a/carcara/src/ast/macros.rs
+++ b/carcara/src/ast/macros.rs
@@ -172,6 +172,8 @@ macro_rules! match_term {
     (@GET_VARIANT bbterm)   => { $crate::ast::Operator::BvBbTerm };
     (@GET_VARIANT bvult)    => { $crate::ast::Operator::BvULt };
     (@GET_VARIANT bvadd)    => { $crate::ast::Operator::BvAdd };
+    (@GET_VARIANT cl)    => { $crate::ast::Operator::Cl };
+    (@GET_VARIANT delete)    => { $crate::ast::Operator::Delete };
 
     (@GET_VARIANT extract)     => { $crate::ast::ParamOperator::BvExtract };
     (@GET_VARIANT bit_of)      => { $crate::ast::ParamOperator::BvBitOf };
@@ -233,6 +235,13 @@ macro_rules! build_term {
             op_args: vec![ $(build_term!($pool, $op_args)),+ ],
             args: vec![ $(build_term!($pool, $args)),+ ],
         };
+        $pool.add(term)
+    }};
+    ($pool:expr, ($op:tt [$arg:expr])) => {{
+        let term = $crate::ast::Term::Op(
+            match_term!(@GET_VARIANT $op),
+            $arg,
+        );
         $pool.add(term)
     }};
     ($pool:expr, ($op:tt $($args:tt)+)) => {{

--- a/carcara/src/ast/polyeq.rs
+++ b/carcara/src/ast/polyeq.rs
@@ -886,5 +886,8 @@ fn nary_case(op: Operator) -> Option<NaryCase> {
         | Operator::BvSGe
         | Operator::BvBbTerm
         | Operator::RareList => None,
+
+        // Clausal
+        Operator::Cl | Operator::Delete => Some(NaryCase::LeftAssoc),
     }
 }

--- a/carcara/src/ast/pool/mod.rs
+++ b/carcara/src/ast/pool/mod.rs
@@ -115,7 +115,9 @@ impl PrimitivePool {
                 | Operator::BvSGt
                 | Operator::BvSGe
                 | Operator::BvShl
-                | Operator::BvLShr => Sort::Bool,
+                | Operator::BvLShr
+                | Operator::Cl
+                | Operator::Delete => Sort::Bool,
                 Operator::BvAdd
                 | Operator::BvSub
                 | Operator::BvNot

--- a/carcara/src/ast/term.rs
+++ b/carcara/src/ast/term.rs
@@ -357,6 +357,10 @@ pub enum Operator {
     // Misc.
     /// The `rare-list` operator, used to represent RARE lists.
     RareList,
+
+    // The clausal operators
+    Cl,
+    Delete,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -474,6 +478,9 @@ impl_str_conversion_traits!(Operator {
     BvBbTerm: "bbterm",
 
     RareList: "rare-list",
+
+    Cl: "cl",
+    Delete: "@d"
 });
 
 impl_str_conversion_traits!(ParamOperator {

--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -23,6 +23,9 @@ pub enum CheckerError {
     Resolution(#[from] crate::resolution::ResolutionError),
 
     #[error(transparent)]
+    DrupFormatError(#[from] crate::drup::DrupFormatError),
+
+    #[error(transparent)]
     Cong(#[from] CongruenceError),
 
     #[error(transparent)]

--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -482,6 +482,10 @@ impl<'c> ProofChecker<'c> {
             "re_unfold_neg" => strings::re_unfold_neg,
             "re_unfold_neg_concat_fixed_prefix" => strings::re_unfold_neg_concat_fixed_prefix,
             "re_unfold_neg_concat_fixed_suffix" => strings::re_unfold_neg_concat_fixed_suffix,
+            // Drup format rules
+            "drup" => |x| drup::drup(false, x),
+            // Drup format rules
+            "drat" => |x| drup::drup(true, x),
 
             // Special rules that always check as valid, and are used to indicate holes in the
             // proof.

--- a/carcara/src/checker/rules/drup.rs
+++ b/carcara/src/checker/rules/drup.rs
@@ -1,0 +1,78 @@
+use super::{CheckerError, RuleArgs, RuleResult};
+use crate::ast::*;
+use crate::drup::*;
+
+pub fn drup(
+    check_drat: bool,
+    RuleArgs {
+        pool, conclusion, premises, args, ..
+    }: RuleArgs,
+) -> RuleResult {
+    let premises: Vec<Rc<Term>> = premises
+        .iter()
+        .map(|p| p.clause)
+        .map(|p| build_term!(pool, (cl[p.to_vec()])))
+        .collect();
+
+    let conclusion = build_term!(pool, (cl[conclusion.to_vec()]));
+
+    match check_drup(pool, conclusion, premises.as_slice(), args, check_drat) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(CheckerError::DrupFormatError(err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn drup() {
+        test_cases! {
+            definitions = "
+                (declare-const a Bool)
+                (declare-const b Bool)
+                (declare-const c Bool)
+                (declare-const d Bool)
+                (declare-const e Bool)
+            ",
+            "Simple working examples" {
+                "(assume a0 (or a c))
+                (assume a1 (or a (not c) d))
+                (assume a2 (or (not d) e))
+                (assume a3 (or (not d) (not e)))
+                (assume a4 (not a))
+                (assume a5 (not b))
+                (step t0 (cl a c) :rule or :premises (a0))
+                (step t1 (cl a (not c) d) :rule or :premises (a1))
+                (step t2 (cl (not d) e) :rule or :premises (a2))
+                (step t3 (cl (not d) (not e)) :rule or :premises (a3))
+                (step t4 (cl a b) :rule drup :premises (t0 t1 t2 t3) :args ((cl a b)))": true,
+
+                "
+                (assume a1 (not a))
+                (assume a2 (not b))
+                (assume a3 (or a b))
+                (step t0 (cl a b) :rule or :premises (a3))
+                (step t1 (cl) :rule drup :premises (a1 a2 t0) :args ((cl)))": true,
+            }
+
+            "Simple false-working examples" {
+                "(assume a0 (or a c))
+                (assume a1 (or a (not c) d))
+                (assume a2 (or (not d) e))
+                (assume a4 (not a))
+                (assume a5 (not b))
+                (step t0 (cl a c) :rule or :premises (a0))
+                (step t1 (cl a (not c) d) :rule or :premises (a1))
+                (step t2 (cl (not d) e) :rule or :premises (a2))
+                (step t4 (cl a) :rule drup :premises (t0 t1 t2) :args ((cl a b)))": false,
+
+                "
+                (assume a1 (not a))
+                (assume a3 (or a b))
+                (step t0 (cl a b) :rule or :premises (a3))
+                (step t1 (cl) :rule drup :premises (a1 t0) :args ((cl)))": false,
+            }
+
+        }
+    }
+}

--- a/carcara/src/checker/rules/mod.rs
+++ b/carcara/src/checker/rules/mod.rs
@@ -222,6 +222,7 @@ macro_rules! test_cases {
 pub(super) mod bitvectors;
 pub(super) mod clausification;
 pub(super) mod congruence;
+pub(super) mod drup;
 pub(super) mod extras;
 pub(super) mod linear_arithmetic;
 pub(super) mod quantifier;

--- a/carcara/src/drup.rs
+++ b/carcara/src/drup.rs
@@ -1,0 +1,329 @@
+use crate::ast::*;
+use indexmap::IndexSet;
+use std::borrow::{Borrow, BorrowMut};
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use thiserror::Error;
+
+#[derive(Debug)]
+pub enum Implied<T, X> {
+    Pivot(T, X),
+    Bottom(X),
+    NotUnsat(),
+}
+
+pub type RupAdition = Vec<(IndexSet<(bool, Rc<Term>)>, Option<(bool, Rc<Term>)>, u64)>;
+
+pub enum DRupProofAction {
+    RupStory(IndexSet<(bool, Rc<Term>)>, RupAdition),
+    Delete(Rc<Term>),
+}
+
+pub type DRupStory = Vec<DRupProofAction>;
+
+#[derive(Debug, Error)]
+pub enum DrupFormatError {
+    #[error("couldn't find conclusion term in the premise clauses")]
+    NoConclusionInPremise,
+    #[error(
+        "couldn't elaborate drup because bottom wasn't derived from the premises and the argument"
+    )]
+    NoFinalBottomInDrup,
+    #[error("couldn't elaborate drup because the argument might not be in RUP")]
+    PotentialNoDrupFormat,
+    #[error("a clause in RAT should be non-empty")]
+    CheckingRatInEmptyClause,
+    #[error("the clause isn't in RAT format")]
+    NotInRatFormat,
+}
+
+pub fn hash_term<T: Borrow<Rc<Term>>>(pool: &mut dyn TermPool, term: T) -> u64 {
+    let term: Rc<Term> = {
+        let (p, regular_term): (bool, &Rc<Term>) =
+            term.borrow().remove_all_negations_with_polarity();
+        if p {
+            regular_term.clone()
+        } else {
+            build_term!(pool, (not { (*regular_term).clone() }))
+        }
+    };
+
+    let mut s = DefaultHasher::new();
+    term.hash(&mut s);
+    let hash = s.finish();
+    return hash;
+}
+
+fn get_implied_clause(
+    clauses: &mut Vec<(
+        (Option<(bool, Rc<Term>)>, Option<(bool, Rc<Term>)>),
+        (IndexSet<(bool, Rc<Term>)>, u64),
+    )>,
+    env: &HashMap<(bool, Rc<Term>), bool>,
+) -> Implied<(bool, Rc<Term>), (IndexSet<(bool, Rc<Term>)>, u64)> {
+    if clauses.is_empty() {
+        return Implied::NotUnsat();
+    }
+
+    for (schema, (lits, key)) in clauses {
+        match schema {
+            (None, None) => return Implied::Bottom(((*lits).clone(), *key)),
+
+            (Some((b, t)), None) | (None, Some((b, t))) => match env.get(&(*b, (*t).clone())) {
+                Some(false) => {
+                    assert_eq!(lits.len(), 1);
+                    return Implied::Bottom(((*lits).clone(), *key));
+                }
+                Some(true) => continue,
+                None => {
+                    assert_eq!(lits.len(), 1);
+                    return Implied::Pivot((*b, (*t).clone()), ((*lits).clone(), *key));
+                }
+            },
+
+            (Some((b, t)), Some((b0, t0))) => {
+                match (env.get(&(*b, (*t).clone())), env.get(&(*b0, (*t0).clone()))) {
+                    (Some(true), _) => continue,
+                    (_, Some(true)) => continue,
+                    (None, None) => continue,
+                    (_, _) => {
+                        let mut unset_literal = None;
+                        let mut not_unit = false;
+
+                        for (b1, t1) in lits.iter() {
+                            let assign_state = env.get(&(*b1, (*t1).clone()));
+
+                            match assign_state {
+                                None => {
+                                    let literal = Some((*b1, (*t1).clone()));
+                                    if schema.0 != literal && schema.1 != literal {
+                                        if schema.0 != None {
+                                            schema.0 = literal;
+                                        } else if schema.1 != None {
+                                            schema.1 = literal;
+                                        }
+                                    }
+
+                                    if unset_literal.is_some() {
+                                        not_unit = true;
+                                        continue;
+                                    }
+
+                                    unset_literal = Some((b1, (*t1).clone()));
+                                }
+                                Some(true) => {
+                                    // Set the true clause as a watched literal to avoid searching O(n) in this "deleted" clause
+                                    let literal = Some((*b1, (*t1).clone()));
+                                    if schema.0 != literal && schema.1 != literal {
+                                        if schema.0 != None {
+                                            schema.0 = literal;
+                                        } else if schema.1 != None {
+                                            schema.1 = literal;
+                                        }
+                                    }
+
+                                    not_unit = true;
+                                    continue;
+                                }
+                                Some(false) => (),
+                            }
+                        }
+
+                        if not_unit {
+                            continue;
+                        }
+
+                        return match unset_literal {
+                            Some((p, polarity)) => {
+                                Implied::Pivot((*p, polarity.clone()), ((*lits).clone(), *key))
+                            }
+                            _ => Implied::Bottom(((*lits).clone(), *key)),
+                        };
+                    }
+                }
+            }
+        }
+    }
+    Implied::NotUnsat()
+}
+
+fn rup<'a, 'b>(
+    pool: &mut dyn TermPool,
+    drup_clauses: &HashMap<u64, IndexSet<(bool, Rc<Term>)>>,
+    goal: &'a [Rc<Term>],
+) -> Option<RupAdition> {
+    let mut unit_story: RupAdition = vec![];
+
+    let mut clauses: Vec<(
+        (Option<(bool, Rc<Term>)>, Option<(bool, Rc<Term>)>),
+        (IndexSet<(bool, Rc<Term>)>, u64),
+    )> = vec![];
+
+    let mut env: HashMap<(bool, Rc<Term>), bool> = HashMap::new();
+
+    for term in goal {
+        let (p, regular_term) = term.remove_all_negations_with_polarity();
+        let mut clause: IndexSet<(bool, Rc<Term>)> = IndexSet::new();
+        clause.insert((!p, regular_term.clone()));
+        clauses.push((
+            (Some((!p, regular_term.clone())), None),
+            (clause, hash_term(pool, term)),
+        ));
+    }
+
+    for (key, clause) in drup_clauses {
+        let mut watched_literals = clause.iter().take(2);
+        let clause = (
+            (
+                watched_literals.next().map(|v| (v.0, v.1.clone())),
+                watched_literals.next().map(|v| (v.0, v.1.clone())),
+            ),
+            (
+                clause.iter().map(|(k, v)| (*k, (*v).clone())).collect(),
+                *key,
+            ),
+        );
+        clauses.push(clause);
+    }
+
+    loop {
+        let unit = get_implied_clause(clauses.borrow_mut(), env.borrow());
+        for (watched_literals, clauses) in clauses.clone() {
+            print!("{:?}\n", watched_literals);
+            for clause in clauses.0 {
+                print!("{:?} = {:?}\n", clause, env.get(&clause));
+            }
+            print!("\n\n");
+        }
+
+        match unit {
+            Implied::Bottom(clause) => {
+                unit_story.push((clause.0, None, clause.1));
+                return Some(unit_story);
+            }
+            Implied::Pivot(literal, clause) => {
+                env.insert(literal.clone(), true);
+                let negated_literal = (!literal.0, literal.1.clone());
+                env.insert(negated_literal.clone(), false);
+                unit_story.push((clause.0, Some((literal.0, literal.1)), clause.1));
+            }
+            Implied::NotUnsat() => return None,
+        }
+    }
+}
+
+pub fn check_drup<'a>(
+    pool: &mut dyn TermPool,
+    conclusion: Rc<Term>,
+    premises: &[Rc<Term>],
+    args: &'a [Rc<Term>],
+    check_rat: bool,
+) -> Result<DRupStory, DrupFormatError> {
+    let mut premises: HashMap<u64, _> = premises
+        .iter()
+        .map(|p| {
+            let mut indexset = IndexSet::new();
+            let terms = if let Some(terms) = match_term!((cl ...) = p) {
+                terms.to_vec()
+            } else {
+                vec![(*p).clone()]
+            };
+            for term in terms {
+                let (polarity, new_term) = term.remove_all_negations_with_polarity();
+                indexset.insert((polarity, (*new_term).clone()));
+            }
+            (hash_term(pool, p), indexset)
+        })
+        .collect();
+
+    let mut drup_history: DRupStory = vec![];
+    for t in args {
+        match match_term!((delete (cl ...)) = &t) {
+            Some(terms) => {
+                let clause_term = if terms.len() > 0 {
+                    build_term!(pool, (cl[terms.to_vec()]))
+                } else {
+                    terms[0].clone()
+                };
+                premises.remove(&hash_term(pool, &clause_term));
+                drup_history.push(DRupProofAction::Delete(clause_term));
+                continue;
+            }
+            None => (),
+        }
+
+        let terms = match_term!((cl ...) = &t).unwrap();
+        let mut unit_history: Option<
+            Vec<(IndexSet<(bool, Rc<Term>)>, Option<(bool, Rc<Term>)>, u64)>,
+        > = rup(pool, premises.borrow(), terms);
+        if unit_history == None && terms.len() > 0 && check_rat {
+            unit_history = check_drat(pool, premises.borrow(), terms);
+        }
+
+        if unit_history == None {
+            return if check_rat {
+                Err(DrupFormatError::NotInRatFormat)
+            } else {
+                Err(DrupFormatError::NoFinalBottomInDrup)
+            };
+        }
+
+        let terms_indexed_set = terms
+            .iter()
+            .map(|term| {
+                let (p, term) = Rc::remove_all_negations_with_polarity(term);
+                (p, term.clone())
+            })
+            .collect::<IndexSet<_>>();
+
+        drup_history.push(DRupProofAction::RupStory(
+            terms_indexed_set.clone(),
+            unit_history.unwrap(),
+        ));
+
+        premises.insert(hash_term(pool, t), terms_indexed_set);
+    }
+
+    if !premises.contains_key(&hash_term(pool, conclusion)) {
+        return Err(DrupFormatError::NoConclusionInPremise);
+    }
+
+    Ok(drup_history)
+}
+
+pub fn check_drat<'a>(
+    pool: &mut dyn TermPool,
+    drup_clauses: &HashMap<u64, IndexSet<(bool, Rc<Term>)>>,
+    goal: &'a [Rc<Term>],
+) -> Option<RupAdition> {
+    let pivot = &goal[0];
+    let mut unit_history = vec![];
+    for (_, clause) in drup_clauses {
+        let (p, regular_term) = pivot.remove_all_negations_with_polarity();
+        let negated_pivot = (!p, regular_term.clone());
+
+        if clause.contains(&negated_pivot) {
+            let mut resolvent = clause.clone();
+            resolvent.remove(&negated_pivot);
+            let mut resolvent = resolvent
+                .iter()
+                .map(|(p, literal)| {
+                    if *p {
+                        return (*literal).clone();
+                    } else {
+                        return build_term!(pool, (not { (*literal).clone() }));
+                    };
+                })
+                .collect::<Vec<_>>();
+
+            resolvent.append(&mut goal[1..].to_vec());
+            if let Some(history) = rup(pool, drup_clauses, resolvent.borrow()) {
+                unit_history.extend_from_slice(&history);
+                continue;
+            }
+            return None;
+        }
+    }
+
+    return Some(unit_history);
+}

--- a/carcara/src/drup.rs
+++ b/carcara/src/drup.rs
@@ -2,7 +2,8 @@ use crate::ast::*;
 use indexmap::IndexSet;
 use std::borrow::{Borrow, BorrowMut};
 use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use thiserror::Error;
 
 #[derive(Debug)]

--- a/carcara/src/lib.rs
+++ b/carcara/src/lib.rs
@@ -38,6 +38,7 @@
 pub mod ast;
 pub mod benchmarking;
 pub mod checker;
+mod drup;
 pub mod elaborator;
 pub mod parser;
 mod resolution;

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -435,6 +435,13 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     }
                 }
             }
+            Operator::Cl => {
+                SortError::assert_eq(&Sort::Bool, sorts[0])?;
+            }
+            Operator::Delete => {
+                SortError::assert_eq(&Sort::Bool, sorts[0])?;
+                assert_num_args(&args, 1)?;
+            }
             Operator::BvAdd
             | Operator::BvMul
             | Operator::BvAnd

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -435,9 +435,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     }
                 }
             }
-            Operator::Cl => {
-                SortError::assert_eq(&Sort::Bool, sorts[0])?;
-            }
+            Operator::Cl => {}
             Operator::Delete => {
                 SortError::assert_eq(&Sort::Bool, sorts[0])?;
                 assert_num_args(&args, 1)?;
@@ -1593,6 +1591,11 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     Reserved::Lambda => self.parse_binder(Binder::Lambda),
                     Reserved::Bang => self.parse_annotated_term(),
                     Reserved::Let => self.parse_let_term(),
+                    Reserved::Cl => {
+                        let args = self.parse_sequence(Self::parse_term, false)?;
+                        self.make_op(Operator::Cl, args)
+                            .map_err(|err| Error::Parser(err, head_pos))
+                    }
                     _ => Err(Error::Parser(
                         ParserError::UnexpectedToken(Token::ReservedWord(reserved)),
                         head_pos,


### PR DESCRIPTION
This PR adds DRAT and optionally DRUP checking rules. 

The rule is represented by:
`(step t4 (cl a) :rule drup :premises (t0 t1 t2) :args ((cl a b)))` or
`(step t4 (cl a) :rule drat :premises (t0 t1 t2) :args ((cl a b)))
`

Where args is the implied clause as usual. 