### PR TITLE
Add PBBlast Rule Checkers (empty)

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -474,6 +474,21 @@ impl<'c> ProofChecker<'c> {
             "concat_cprop_prefix" => strings::concat_cprop_prefix,
             "concat_cprop_suffix" => strings::concat_cprop_suffix,
 
+            // pseudo-boolean bitblasting
+            "pbblast_bveq" => pb_blasting::pbblast_bveq,
+            "pbblast_bvult" => pb_blasting::pbblast_bvult,
+            "pbblast_bvugt" => pb_blasting::pbblast_bvugt,
+            "pbblast_bvuge" => pb_blasting::pbblast_bvuge,
+            "pbblast_bvule" => pb_blasting::pbblast_bvule,
+            "pbblast_bvslt" => pb_blasting::pbblast_bvslt,
+            "pbblast_bvsgt" => pb_blasting::pbblast_bvsgt,
+            "pbblast_bvsge" => pb_blasting::pbblast_bvsge,
+            "pbblast_bvsle" => pb_blasting::pbblast_bvsle,
+            "pbblast_pbbvar" => pb_blasting::pbblast_pbbvar,
+            "pbblast_pbbconst" => pb_blasting::pbblast_pbbconst,
+            "pbblast_bvxor" => pb_blasting::pbblast_bvxor,
+            "pbblast_bvand" => pb_blasting::pbblast_bvand,
+
             "string_decompose" => strings::string_decompose,
             "string_length_pos" => strings::string_length_pos,
             "string_length_non_empty" => strings::string_length_non_empty,

--- a/carcara/src/checker/rules/mod.rs
+++ b/carcara/src/checker/rules/mod.rs
@@ -248,6 +248,7 @@ pub(super) mod clausification;
 pub(super) mod congruence;
 pub(super) mod extras;
 pub(super) mod linear_arithmetic;
+pub(super) mod pb_blasting;
 pub(super) mod quantifier;
 pub(super) mod reflexivity;
 pub(super) mod resolution;

--- a/carcara/src/checker/rules/pb_blasting.rs
+++ b/carcara/src/checker/rules/pb_blasting.rs
@@ -1,0 +1,112 @@
+use super::{RuleArgs, RuleResult};
+
+/// Implements the equality rule
+/// The expected shape is:
+///    `(= (= x y) (= (- (+ sum_x) (+ sum_y)) 0))`
+pub fn pbblast_bveq(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the unsigned-less-than rule.
+/// The expected shape is:
+///    `(= (bvult x y) (>= (- (+ sum_y) (+ sum_x)) 1))`
+pub fn pbblast_bvult(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the unsigned-greater-than rule.
+///
+/// The expected shape is:
+///    `(= (bvugt x y) (>= (- (+ sum_x) (+ sum_y)) 1))`
+pub fn pbblast_bvugt(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the unsigned-greater-or-equal rule.
+///
+/// The expected shape is:
+///    `(= (bvuge x y) (>= (- (+ sum_x) (+ sum_y)) 0))`
+pub fn pbblast_bvuge(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the unsigned-less-or-equal rule.
+///
+/// The expected shape is:
+///    `(= (bvule x y) (>= (- (+ sum_y) (+ sum_x)) 0))`
+pub fn pbblast_bvule(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the signed-less-than rule.
+///
+/// The expected shape is:
+///    `(= (bvslt x y) (>= (+ (- y_sum (* 2^(n-1) y_n-1))) (- (* 2^(n-1) x_n-1) x_sum)) 1))`
+pub fn pbblast_bvslt(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the signed-greater-than rule.
+///
+/// The expected shape is:
+///    `(= (bvsgt x y) (>= (+ (- x_sum (* 2^(n-1) x_n-1))) (- (* 2^(n-1) y_n-1) y_sum)) 1))`
+pub fn pbblast_bvsgt(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the signed-greater-equal rule.
+///
+/// The expected shape is:
+///    `(= (bvsge x y) (>= (+ (- x_sum (* 2^(n-1) x_n-1))) (- (* 2^(n-1) y_n-1) y_sum)) 0))`
+pub fn pbblast_bvsge(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the signed-less-equal rule.
+///
+/// The expected shape is:
+///    `(= (bvsle x y) (>= (+ (- y_sum (* 2^(n-1) y_n-1))) (- (* 2^(n-1) x_n-1) x_sum)) 0))`
+pub fn pbblast_bvsle(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the blasting of a bitvector variable
+pub fn pbblast_pbbvar(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the blasting of a constant
+pub fn pbblast_pbbconst(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the bitwise exclusive or operation.
+pub fn pbblast_bvxor(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+/// Implements the bitwise and operation.
+pub fn pbblast_bvand(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    Ok(())
+}
+
+mod tests {
+    #[test]
+    fn pbblast_bveq_1() {
+        test_cases! {
+            definitions = "
+            (declare-const x1 (_ BitVec 1))
+            (declare-const y1 (_ BitVec 1))
+        ",
+
+            // Check that equality on single-bit bitvectors is accepted when
+            // the summation for each side explicitly multiplies by 1.
+            "Equality on single bits" {
+                r#"(step t1 (cl (= (= x1 y1)
+                                 (= (- (+ (* 1 ((_ int_of 0) x1)) 0)
+                                       (+ (* 1 ((_ int_of 0) y1)) 0))
+                                    0))) :rule pbblast_bveq)"#: true,
+            }
+        }
+    }
+}

--- a/carcara/src/checker/rules/pb_blasting.rs
+++ b/carcara/src/checker/rules/pb_blasting.rs
@@ -1,112 +1,204 @@
 use super::{RuleArgs, RuleResult};
+use crate::checker::error::CheckerError;
 
 /// Implements the equality rule
 /// The expected shape is:
 ///    `(= (= x y) (= (- (+ sum_x) (+ sum_y)) 0))`
-pub fn pbblast_bveq(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bveq(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the unsigned-less-than rule.
 /// The expected shape is:
 ///    `(= (bvult x y) (>= (- (+ sum_y) (+ sum_x)) 1))`
-pub fn pbblast_bvult(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvult(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the unsigned-greater-than rule.
 ///
 /// The expected shape is:
 ///    `(= (bvugt x y) (>= (- (+ sum_x) (+ sum_y)) 1))`
-pub fn pbblast_bvugt(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvugt(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the unsigned-greater-or-equal rule.
 ///
 /// The expected shape is:
 ///    `(= (bvuge x y) (>= (- (+ sum_x) (+ sum_y)) 0))`
-pub fn pbblast_bvuge(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvuge(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the unsigned-less-or-equal rule.
 ///
 /// The expected shape is:
 ///    `(= (bvule x y) (>= (- (+ sum_y) (+ sum_x)) 0))`
-pub fn pbblast_bvule(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvule(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the signed-less-than rule.
 ///
 /// The expected shape is:
 ///    `(= (bvslt x y) (>= (+ (- y_sum (* 2^(n-1) y_n-1))) (- (* 2^(n-1) x_n-1) x_sum)) 1))`
-pub fn pbblast_bvslt(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvslt(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the signed-greater-than rule.
 ///
 /// The expected shape is:
 ///    `(= (bvsgt x y) (>= (+ (- x_sum (* 2^(n-1) x_n-1))) (- (* 2^(n-1) y_n-1) y_sum)) 1))`
-pub fn pbblast_bvsgt(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvsgt(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the signed-greater-equal rule.
 ///
 /// The expected shape is:
 ///    `(= (bvsge x y) (>= (+ (- x_sum (* 2^(n-1) x_n-1))) (- (* 2^(n-1) y_n-1) y_sum)) 0))`
-pub fn pbblast_bvsge(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvsge(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the signed-less-equal rule.
 ///
 /// The expected shape is:
 ///    `(= (bvsle x y) (>= (+ (- y_sum (* 2^(n-1) y_n-1))) (- (* 2^(n-1) x_n-1) x_sum)) 0))`
-pub fn pbblast_bvsle(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvsle(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the blasting of a bitvector variable
-pub fn pbblast_pbbvar(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_pbbvar(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the blasting of a constant
-pub fn pbblast_pbbconst(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_pbbconst(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the bitwise exclusive or operation.
-pub fn pbblast_bvxor(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvxor(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 /// Implements the bitwise and operation.
-pub fn pbblast_bvand(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
-    Ok(())
+pub fn pbblast_bvand(RuleArgs { .. }: RuleArgs) -> RuleResult {
+    Err(CheckerError::Unspecified)
 }
 
 mod tests {
     #[test]
-    fn pbblast_bveq_1() {
-        test_cases! {
-            definitions = "
-            (declare-const x1 (_ BitVec 1))
-            (declare-const y1 (_ BitVec 1))
-        ",
+    fn pbblast_bveq_1() {}
 
-            // Check that equality on single-bit bitvectors is accepted when
-            // the summation for each side explicitly multiplies by 1.
-            "Equality on single bits" {
-                r#"(step t1 (cl (= (= x1 y1)
-                                 (= (- (+ (* 1 ((_ int_of 0) x1)) 0)
-                                       (+ (* 1 ((_ int_of 0) y1)) 0))
-                                    0))) :rule pbblast_bveq)"#: true,
-            }
-        }
-    }
+    #[test]
+    fn pbblast_bveq_2() {}
+
+    #[test]
+    fn pbblast_bveq_8() {}
+
+    #[test]
+    fn pbblast_bvult_1() {}
+
+    #[test]
+    fn pbblast_bvult_2() {}
+
+    #[test]
+    fn pbblast_bvult_8() {}
+
+    #[test]
+    fn pbblast_bvugt_1() {}
+
+    #[test]
+    fn pbblast_bvugt_2() {}
+
+    #[test]
+    fn pbblast_bvugt_8() {}
+
+    #[test]
+    fn pbblast_bvuge_1() {}
+
+    #[test]
+    fn pbblast_bvuge_2() {}
+
+    #[test]
+    fn pbblast_bvuge_8() {}
+
+    #[test]
+    fn pbblast_bvule_1() {}
+
+    #[test]
+    fn pbblast_bvule_2() {}
+
+    #[test]
+    fn pbblast_bvule_8() {}
+
+    // TODO: What should happen to a signed operation on BitVec 1 ??
+
+    #[test]
+    fn pbblast_bvslt_2() {}
+
+    #[test]
+    fn pbblast_bvslt_4() {}
+
+    #[test]
+    fn pbblast_bvsgt_2() {}
+
+    #[test]
+    fn pbblast_bvsgt_4() {}
+
+    #[test]
+    fn pbblast_bvsge_2() {}
+
+    #[test]
+    fn pbblast_bvsge_4() {}
+
+    #[test]
+    fn pbblast_bvsle_2() {}
+
+    #[test]
+    fn pbblast_bvsle_4() {}
+
+    #[test]
+    fn pbblast_pbbvar_1() {}
+
+    #[test]
+    fn pbblast_pbbvar_2() {}
+
+    #[test]
+    fn pbblast_pbbvar_8() {}
+
+    #[test]
+    fn pbblast_pbbconst_1() {}
+
+    #[test]
+    fn pbblast_pbbconst_2() {}
+
+    #[test]
+    fn pbblast_pbbconst_4() {}
+
+    #[test]
+    fn pbblast_pbbconst_8() {}
+
+    #[test]
+    fn pbblast_bvxor_1() {}
+
+    #[test]
+    fn pbblast_bvxor_2() {}
+
+    #[test]
+    fn pbblast_bvxor_8() {}
+
+    #[test]
+    fn pbblast_bvand_1() {}
+
+    #[test]
+    fn pbblast_bvand_2() {}
+
+    #[test]
+    fn pbblast_bvand_8() {}
 }

--- a/carcara/src/parser/error.rs
+++ b/carcara/src/parser/error.rs
@@ -61,7 +61,7 @@ pub enum ParserError {
     #[error("sort error: {0}")]
     SortError(#[from] SortError),
 
-    /// Expected BvSort
+    /// Expected `BvSort`
     #[error("expected bitvector sort, got '{0}'")]
     ExpectedBvSort(Sort),
 


### PR DESCRIPTION
# Add PBBlast Rule Checkers

This PR introduces the initial declarations for PBBlast rule checkers.

## Changes

- Added empty function stubs for PBBlast rules covering various operations:
    - **Equality and Comparisons**:
        - `pbblast_bveq`, `pbblast_bvult`, `pbblast_bvugt`, `pbblast_bvuge`, `pbblast_bvule`
        - Signed variants: `pbblast_bvslt`, `pbblast_bvsgt`, `pbblast_bvsge`, `pbblast_bvsle`
    - **Core Blasting**:
        - `pbblast_pbbvar` (bitvector variables)
        - `pbblast_pbbconst` (constants)
    - **Bitwise Operations**:
        - `pbblast_bvxor` (XOR)
        - `pbblast_bvand` (AND)

Unit tests for each rule will be implemented and will be used to validate the implementation once the checker functions are fully developed in subsequent PRs.

Note: All checker functions currently return `Err(CheckerError::Unspecified)` as placeholders. This PR focuses on setting up the architectural foundation and test infrastructure to enable incremental implementation of the rules.