### PR TITLE
Implement Cutting Planes Multiplication Rule Checker (`cp_multiplication`)

### DIFF
--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -213,8 +213,46 @@ pub fn cp_addition(RuleArgs { premises, args, conclusion, .. }: RuleArgs) -> Rul
     Ok(())
 }
 
-pub fn cp_multiplication(RuleArgs { .. }: RuleArgs) -> RuleResult {
-    Err(CheckerError::Unspecified)
+pub fn cp_multiplication(RuleArgs { premises, args, conclusion, .. }: RuleArgs) -> RuleResult {
+    // Check there is exactly one premise
+    assert_num_premises(premises, 1)?;
+    assert_clause_len(premises[0].clause, 1)?;
+    let clause = &premises[0].clause[0];
+
+    // Check there is exactly one arg
+    assert_num_args(args, 1)?;
+    let scalar: Integer = args[0].as_integer_err()?;
+
+    // Check there is exactly one conclusion
+    assert_clause_len(conclusion, 1)?;
+    let conclusion = &conclusion[0];
+
+    // Unwrap the premise inequality
+    let (pbsum_p, constant_p) = unwrap_pseudoboolean_inequality(clause)?;
+
+    // Unwrap the conclusion inequality
+    let (pbsum_c, constant_c) = unwrap_pseudoboolean_inequality(conclusion)?;
+
+    // Verify constants match
+    rassert!(
+        scalar.clone() * constant_p.clone() == constant_c,
+        CheckerError::ExpectedInteger(scalar.clone() * constant_p, conclusion.clone())
+    );
+
+    // Verify premise and conclusion share same keys
+    assert_pbsum_same_keys(&pbsum_p, &pbsum_c)?;
+
+    // Verify pseudo-boolean sums match
+    for (literal, coeff_p) in pbsum_p {
+        if let Some(coeff_c) = pbsum_c.get(&literal) {
+            let expected = &scalar * coeff_p;
+            rassert!(
+                &expected == coeff_c,
+                CheckerError::ExpectedInteger(expected.clone(), conclusion.clone())
+            );
+        }
+    }
+    Ok(())
 }
 
 pub fn cp_division(RuleArgs { .. }: RuleArgs) -> RuleResult {
@@ -291,7 +329,53 @@ mod tests {
     }
 
     #[test]
-    fn cp_multiplication() {}
+    fn cp_multiplication() {
+        test_cases! {
+            definitions = "
+                (declare-fun x1 () Int)
+                (declare-fun x2 () Int)
+                (declare-fun x3 () Int)
+                ",
+            "Simple working examples" {
+                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 3 x3) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 6 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 (- 1 x2)) (* 3 x3) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 (- 1 x2)) (* 6 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+            }
+            "Wrong number of premises" {
+                r#"(assume c1 (>= x1 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :args (2))"#: false,
+                r#"(assume c1 (>= x1 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :premises (c1 c1) :args (2))"#: false,
+            }
+            "Wrong number of args" {
+                r#"(assume c1 (>= x1 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :premises (c1))"#: false,
+                r#"(assume c1 (>= x1 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :premises (c1) :args (2 3))"#: false,
+            }
+            "Wrong number of clauses in the conclusion" {
+                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 2 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+            }
+            "Wrong product" {
+                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 3 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 4 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 3 x3) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 3 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+            }
+
+        }
+    }
 
     #[test]
     fn cp_division() {}

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -337,14 +337,14 @@ mod tests {
                 (declare-fun x3 () Int)
                 ",
             "Simple working examples" {
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 3 x3) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 6 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 (- 1 x2)) (* 3 x3) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 4 (- 1 x2)) (* 6 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2)) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 3 x3)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 6 x3)) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 (- 1 x2)) (* 3 x3)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 (- 1 x2)) (* 6 x3)) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: true,
             }
             "Wrong number of premises" {
                 r#"(assume c1 (>= x1 1))
@@ -359,19 +359,29 @@ mod tests {
                    (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :premises (c1) :args (2 3))"#: false,
             }
             "Wrong number of clauses in the conclusion" {
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 2 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 2 x2)) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
 
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2)) 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
             }
             "Wrong product" {
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (step t1 (cl (>= (* 3 x1) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2)) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 4 x2)) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 3 x3)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 3 x3)) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+            }
+            "Trailing Zero" {
                 r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 3 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
                 r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x1) (* 4 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
                 r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 3 x3) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 3 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 x2) (* 6 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 (- 1 x2)) (* 3 x3) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 4 (- 1 x2)) (* 6 x3) 0) 2)) :rule cp_multiplication :premises (c1) :args (2))"#: false,
             }
 
         }


### PR DESCRIPTION
# Implement Cutting Planes Multiplication Rule Checker (`cp_multiplication`)

This PR implements the `cp_multiplication` rule checker for cutting planes proofs with comprehensive validation logic.

## Changes

### Core Implementation
- Added `cp_multiplication` checker that:
  - Reuses the helper functions
  - Ensures conclusion matches reduced premise combination times scalar
  
- Depends on #63 

