### PR TITLE
Implement Cutting Planes Saturation Rule Checker (`cp_saturation`)

### DIFF
--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -221,8 +221,42 @@ pub fn cp_division(RuleArgs { .. }: RuleArgs) -> RuleResult {
     Err(CheckerError::Unspecified)
 }
 
-pub fn cp_saturation(RuleArgs { .. }: RuleArgs) -> RuleResult {
-    Err(CheckerError::Unspecified)
+pub fn cp_saturation(RuleArgs { premises, args, conclusion, .. }: RuleArgs) -> RuleResult {
+    assert_num_premises(premises, 1)?;
+    assert_num_args(args, 0)?;
+    let clause = &premises[0].clause[0];
+
+    // Check there is exactly one conclusion
+    assert_clause_len(conclusion, 1)?;
+    let conclusion = &conclusion[0];
+
+    // Unwrap the premise inequality
+    let (pbsum_p, constant_p) = unwrap_pseudoboolean_inequality(clause)?;
+
+    // Unwrap the conclusion inequality
+    let (pbsum_c, constant_c) = unwrap_pseudoboolean_inequality(conclusion)?;
+
+    // Verify constants match
+    rassert!(
+        constant_p == constant_c,
+        CheckerError::ExpectedInteger(constant_p.clone(), conclusion.clone())
+    );
+
+    // Verify premise and conclusion share same keys
+    assert_pbsum_same_keys(&pbsum_p, &pbsum_c)?;
+
+    // Verify saturation of variables match
+    for (literal, coeff_p) in pbsum_p {
+        if let Some(coeff_c) = pbsum_c.get(&literal) {
+            let expected = Ord::min(&constant_p, &coeff_p);
+            rassert!(
+                expected == coeff_c,
+                CheckerError::ExpectedInteger(expected.clone(), conclusion.clone())
+            );
+        }
+    }
+
+    Ok(())
 }
 
 mod tests {
@@ -297,5 +331,46 @@ mod tests {
     fn cp_division() {}
 
     #[test]
-    fn cp_saturation() {}
+    fn cp_saturation() {
+        test_cases! {
+            definitions = "
+                (declare-fun x1 () Int)
+                (declare-fun x2 () Int)
+                (declare-fun x3 () Int)
+                ",
+            "Simple working examples" {
+                r#"(assume c1 (>= (+ (* 2 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) 0) 1)) :rule cp_saturation :premises (c1))"#: true,
+
+                r#"(assume c1 (>= (+ (* 2 x1) (* 5 x2) (* 3 x3) 0) 3))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2) (* 3 x3) 0) 3)) :rule cp_saturation :premises (c1))"#: true,
+
+                r#"(assume c1 (>= (+ (* 3 x1) (* 4 x2) (* 5 x3) 0) 3))
+                   (step t1 (cl (>= (+ (* 3 x1) (* 3 x2) (* 3 x3) 0) 3)) :rule cp_saturation :premises (c1))"#: true,
+
+                r#"(assume c1 (>= (+ (* 3 x1) (* 4 x2) (* 5 (- 1 x3)) 0) 3))
+                   (step t1 (cl (>= (+ (* 3 x1) (* 3 x2) (* 3 (- 1 x3)) 0) 3)) :rule cp_saturation :premises (c1))"#: true,
+
+            }
+            "Wrong saturation" {
+                r#"(assume c1 (>= (+ (* 2 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) 0) 1)) :rule cp_saturation :premises (c1))"#: false,
+
+                r#"(assume c1 (>= (+ (* 2 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 0 x1) 0) 1)) :rule cp_saturation :premises (c1))"#: false,
+
+                r#"(assume c1 (>= (+ (* 3 x1) (* 4 x2) (* 5 x3) 0) 3))
+                   (step t1 (cl (>= (+ (* 3 x1) (* 3 x2) (* 2 x3) 0) 3)) :rule cp_saturation :premises (c1))"#: false,
+
+            }
+            "Missing terms" {
+                r#"(assume c1 (>= (+ (* 3 x1) (* 4 x2) (* 5 x3) 0) 3))
+                   (step t1 (cl (>= (+ (* 3 x1) (* 3 x2) 0) 3)) :rule cp_saturation :premises (c1))"#: false,
+
+                r#"(assume c1 (>= (+ (* 3 x1) (* 4 x2) 0) 3))
+                   (step t1 (cl (>= (+ (* 3 x1) (* 3 x2) (* 3 x3) 0) 3)) :rule cp_saturation :premises (c1))"#: false,
+            }
+
+        }
+    }
 }

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -22,7 +22,7 @@ fn get_pb_hashmap(pbsum: &[Rc<Term>]) -> Result<PbHash, CheckerError> {
     let mut hm = HashMap::new();
     // let n = pbsum.len() - 1;
 
-    for term in pbsum.iter() {
+    for term in pbsum {
         let (coeff, literal) =
             // Negated literal  (* c (- 1 x1))
             if let Some((coeff, (one, literal))) = match_term!((* coeff (- one literal)) = term) {

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -285,57 +285,82 @@ mod tests {
                 (declare-fun x3 () Int)
                 ",
             "Addition with Reduction" {
-                r#"(assume c1 (>= (+ (* 1 (- 1 x1)) 0) 1))
-                   (assume c2 (>= (+ (* 2 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x1) (* 0 x2) 0) 1)) :rule cp_addition :premises (c1 c2))"#: true,
+                r#"(assume c1 (>= (* 1 (- 1 x1)) 1))
+                   (assume c2 (>= (* 2 x1) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 0 x2)) 1)) :rule cp_addition :premises (c1 c2))"#: true,
 
-                r#"(assume c1 (>= (+ (* 2 x1) 0) 1))
-                   (assume c2 (>= (+ (* 1 (- 1 x1)) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x1) 0) 1)) :rule cp_addition :premises (c1 c2))"#: true,
+                r#"(assume c1 (>= (* 2 x1) 1))
+                   (assume c2 (>= (* 1 (- 1 x1)) 1))
+                   (step t1 (cl (>= (* 1 x1) 1)) :rule cp_addition :premises (c1 c2))"#: true,
 
-                r#"(assume c1 (>= (+ (* 2 x1) (* 3 x2) 0) 2))
-                   (assume c2 (>= (+ (* 1 (- 1 x1)) (* 3 (- 1 x2)) 0) 4))
-                   (step t1 (cl (>= (+ (* 1 x1) 0) 2)) :rule cp_addition :premises (c1 c2))"#: true,
+                r#"(assume c1 (>= (+ (* 2 x1) (* 3 x2)) 2))
+                   (assume c2 (>= (+ (* 1 (- 1 x1)) (* 3 (- 1 x2))) 4))
+                   (step t1 (cl (>= (* 1 x1) 2)) :rule cp_addition :premises (c1 c2))"#: true,
             }
             "Simple working examples" {
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_addition :premises (c1 c1))"#: true,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (step t1 (cl (>= (* 2 x1) 2)) :rule cp_addition :premises (c1 c1))"#: true,
 
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x1) (* 1 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: true,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (assume c2 (>= (* 1 x2) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 1 x2)) 2)) :rule cp_addition :premises (c1 c2))"#: true,
 
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: true,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2)) 1))
+                   (assume c2 (>= (+ (* 1 x2) (* 1 x1)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2)) 2)) :rule cp_addition :premises (c1 c2))"#: true,
 
             }
             "Missing Terms" {
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x1) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (assume c2 (>= (* 1 x2) 1))
+                   (step t1 (cl (>= (* 1 x1) 2)) :rule cp_addition :premises (c1 c2))"#: false,
 
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (assume c2 (>= (* 1 x2) 1))
+                   (step t1 (cl (>= (* 1 x2) 2)) :rule cp_addition :premises (c1 c2))"#: false,
 
-                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) 0) 1))
-                   (step t1 (cl (>= (+ (* 1 x1) (* 1 x2) (* 1 x3) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+                r#"(assume c1 (>= (* 1 x1) 1))
+                   (assume c2 (>= (* 1 x2) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 1 x2) (* 1 x3)) 2)) :rule cp_addition :premises (c1 c2))"#: false,
 
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 1 x3) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) (* 1 x3)) 1))
+                   (assume c2 (>= (+ (* 1 x2) (* 1 x1)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2)) 2)) :rule cp_addition :premises (c1 c2))"#: false,
 
             }
             "Wrong Addition" {
-                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
-                   (assume c2 (>= (+ (* 1 x2) (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 2 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2)) 1))
+                   (assume c2 (>= (+ (* 1 x2) (* 1 x1)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 2 x2)) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+
+                r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2)) 1))
+                   (assume c2 (>= (+ (* 1 x2) (* 1 x1)) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2)) 3)) :rule cp_addition :premises (c1 c2))"#: false,
+            }
+            "Trailing Zero" {
+                r#"(assume c1 (>= (+ (* 1 (- 1 x1)) 0) 1))
+                   (assume c2 (>= (+ (* 2 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 0 x2) 0) 1)) :rule cp_addition :premises (c1 c2))"#: false,
+
+                r#"(assume c1 (>= (+ (* 2 x1) 0) 1))
+                   (assume c2 (>= (+ (* 1 (- 1 x1)) 0) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) 0) 1)) :rule cp_addition :premises (c1 c2))"#: false,
+
+                r#"(assume c1 (>= (+ (* 2 x1) (* 3 x2) 0) 2))
+                   (assume c2 (>= (+ (* 1 (- 1 x1)) (* 3 (- 1 x2)) 0) 4))
+                   (step t1 (cl (>= (+ (* 1 x1) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+
+                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
+                   (step t1 (cl (>= (+ (* 2 x1) 0) 2)) :rule cp_addition :premises (c1 c1))"#: false,
+
+                r#"(assume c1 (>= (+ (* 1 x1) 0) 1))
+                   (assume c2 (>= (+ (* 1 x2) 0) 1))
+                   (step t1 (cl (>= (+ (* 1 x1) (* 1 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
 
                 r#"(assume c1 (>= (+ (* 1 x1) (* 2 x2) 0) 1))
                    (assume c2 (>= (+ (* 1 x2) (* 1 x1) 0) 1))
-                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2) 0) 3)) :rule cp_addition :premises (c1 c2))"#: false,
+                   (step t1 (cl (>= (+ (* 2 x1) (* 3 x2) 0) 2)) :rule cp_addition :premises (c1 c2))"#: false,
+
             }
         }
     }

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -20,7 +20,6 @@ fn equals_integer_err(term: &Rc<Term>, expected: &Integer) -> Result<(), Checker
 
 fn get_pb_hashmap(pbsum: &[Rc<Term>]) -> Result<PbHash, CheckerError> {
     let mut hm = HashMap::new();
-    // let n = pbsum.len() - 1;
 
     for term in pbsum {
         let (coeff, literal) =
@@ -58,7 +57,6 @@ fn unwrap_pseudoboolean_inequality(clause: &Rc<Term>) -> Result<(PbHash, Integer
         )));
     };
 
-    // let (pbsum, constant) = match_term_err!((>= (+ ...) constant) = clause)?;
     let constant = constant.as_integer_err()?;
     let pbsum = get_pb_hashmap(pbsum)?;
     Ok((pbsum, constant))
@@ -66,13 +64,11 @@ fn unwrap_pseudoboolean_inequality(clause: &Rc<Term>) -> Result<(PbHash, Integer
 
 fn add_pbsums(pbsum_a: &PbHash, pbsum_b: &PbHash) -> PbHash {
     let mut res = pbsum_a.clone();
-
     for (lit, cb) in pbsum_b {
         res.entry(lit.clone())
             .and_modify(|ca| *ca += cb)
             .or_insert(cb.clone());
     }
-
     res
 }
 


### PR DESCRIPTION
# Implement Cutting Planes Saturation Rule Checker (`cp_saturation`)

This PR implements the `cp_saturation` rule checker for cutting planes proofs with comprehensive validation logic.

## Changes

### Core Implementation
- Added `cp_saturation` checker that:
  - Reuses the helper functions
  - Ensures conclusion matches minimum between premise and the constant
 
- Change the addition tests and `unwrap_pseudoboolean_inequality` to account for a summation list of two elements or more differently than a single term (no summation)

