### PR TITLE
Implement PBBlast `pbblast_pbbvar` rule

### DIFF
--- a/carcara/src/checker/rules/pb_blasting.rs
+++ b/carcara/src/checker/rules/pb_blasting.rs
@@ -197,8 +197,27 @@ pub fn pbblast_bvsle(RuleArgs { .. }: RuleArgs) -> RuleResult {
 }
 
 /// Implements the blasting of a bitvector variable
-pub fn pbblast_pbbvar(RuleArgs { .. }: RuleArgs) -> RuleResult {
-    Err(CheckerError::Unspecified)
+pub fn pbblast_pbbvar(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+    let (x, pbs) = match_term_err!((= x (pbbterm ...)) = &conclusion[0])?;
+
+    for (i, pb) in pbs.iter().enumerate() {
+        let (idx, bv) = match_term_err!(((_ int_of idx) bv) = pb)?;
+
+        // Convert the index term to an integer.
+        let idx: Integer = idx.as_integer_err()?;
+
+        // Check that the index is `i`.
+        rassert!(
+            idx == i,
+            CheckerError::Explanation(format!("Index {} is not {}", idx, i))
+        );
+        // Finally, the bitvector in the summand must be the one we expect.
+        rassert!(
+            *bv == *x,
+            CheckerError::Explanation(format!("Mismatched bitvectors {} {}", bv, x))
+        );
+    }
+    Ok(())
 }
 
 /// Implements the blasting of a constant
@@ -440,13 +459,63 @@ mod tests {
     fn pbblast_bvsle_4() {}
 
     #[test]
-    fn pbblast_pbbvar_1() {}
+    fn pbblast_pbbvar_1() {
+        test_cases! {
+           definitions = "
+                (declare-const x (_ BitVec 1))
+                (declare-const y (_ BitVec 1))
+                ",
+            // No restriction, only create a vector of pseudo-boolean variables that are free
+            "pbbvar on single bits" {
+                r#"(step t1 (cl (= x (pbbterm ((_ int_of 0) x)))) :rule pbblast_pbbvar)"#: true,
+                r#"(step t1 (cl (= x (pbbterm ((_ int_of 1) x)))) :rule pbblast_pbbvar)"#: false, // Wrong index
+                r#"(step t1 (cl (= x (pbbterm ((_ int_of 0) y)))) :rule pbblast_pbbvar)"#: false, // Mismatched vectors
+                r#"(step t1 (cl (= y (pbbterm ((_ int_of 0) x)))) :rule pbblast_pbbvar)"#: false, // Mismatched vectors
+            }
+        }
+    }
 
     #[test]
-    fn pbblast_pbbvar_2() {}
+    fn pbblast_pbbvar_2() {
+        test_cases! {
+            definitions = "
+            (declare-const x2 (_ BitVec 2))
+            (declare-const y2 (_ BitVec 2))
+        ",
+            "Valid 2-bit pbbvar" {
+                r#"(step t1 (cl (= x2 (pbbterm ((_ int_of 0) x2) ((_ int_of 1) x2)))) :rule pbblast_pbbvar)"#: true,
+            }
+            "Mixed variables" {
+                r#"(step t1 (cl (= x2 (pbbterm ((_ int_of 0) x2) ((_ int_of 1) y2)))) :rule pbblast_pbbvar)"#: false,
+            }
+        }
+    }
 
     #[test]
-    fn pbblast_pbbvar_8() {}
+    fn pbblast_pbbvar_8() {
+        test_cases! {
+            definitions = "
+            (declare-const x8 (_ BitVec 8))
+        ",
+            "Valid 8-bit pbbvar" {
+                r#"(step t1 (cl (= x8 (pbbterm
+                    ((_ int_of 0) x8) ((_ int_of 1) x8)
+                    ((_ int_of 2) x8) ((_ int_of 3) x8)
+                    ((_ int_of 4) x8) ((_ int_of 5) x8)
+                    ((_ int_of 6) x8) ((_ int_of 7) x8)
+                ))) :rule pbblast_pbbvar)"#: true,
+            }
+
+            "Invalid 8-bit (missing term)" {
+                r#"(step t1 (cl (= x8 (pbbterm
+                    ((_ int_of 0) x8) ((_ int_of 1) x8)
+                    ((_ int_of 2) x8) ((_ int_of 3) x8)
+                    ((_ int_of 4) x8) ((_ int_of 5) x8)
+                    ((_ int_of 6) x8) ((_ int_of 6) x8) ;; index 6 twice
+                ))) :rule pbblast_pbbvar)"#: false,
+            }
+        }
+    }
 
     #[test]
     fn pbblast_pbbconst_1() {}


### PR DESCRIPTION
This PR adds the implementation of the pbblast_pbbvar rule for checking the pseudo-boolean bit blasting of a bitvector variable. 

- Tests for 1, 2 and 8 bits were created, covering indexing and ordering of the bits

- The semantics for this rule are in page 56, rule 114 of [WIP alethe docs](https://gitlab.uliege.be/verit/alethe/-/jobs/188683/artifacts/raw/specification.pdf?inline=false)