### PR TITLE
[parsing] Update parsing of indexed operators

### DIFF
--- a/carcara/src/parser/error.rs
+++ b/carcara/src/parser/error.rs
@@ -140,13 +140,13 @@ where
 }
 
 /// Returns an error if the value of `sequence` is not in the `expected` range.
-pub fn assert_indexed_op_args_value<R>(sequence: &[Constant], range: R) -> Result<(), ParserError>
+pub fn assert_indexed_op_args_value<R>(sequence: &[Rc<Term>], range: R) -> Result<(), ParserError>
 where
     R: Into<Range<Integer>>,
 {
     let range = range.into();
     for x in sequence {
-        if let Constant::Integer(i) = x {
+        if let Term::Const(Constant::Integer(i)) = x.as_ref() {
             if !range.contains(i.clone()) {
                 return Err(ParserError::WrongValueOfArgs(range, i.clone()));
             }

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -1408,7 +1408,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
         Ok(inner)
     }
 
-    fn parse_indexed_operator(&mut self) -> CarcaraResult<(ParamOperator, Vec<Constant>)> {
+    fn parse_indexed_operator(&mut self) -> CarcaraResult<(ParamOperator, Vec<Rc<Term>>)> {
         let op_symbol = self.expect_symbol()?;
 
         if let Some(value) = op_symbol.strip_prefix("bv") {
@@ -1417,7 +1417,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
             let mut constant_args = Vec::new();
             for arg in args {
                 if let Some(i) = arg.as_signed_integer() {
-                    constant_args.push(Constant::Integer(i));
+                    constant_args.push(self.pool.add(Term::Const(Constant::Integer(i))));
                 } else {
                     return Err(Error::Parser(
                         ParserError::ExpectedIntegerConstant(arg.clone()),
@@ -1425,7 +1425,10 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     ));
                 }
             }
-            constant_args.insert(0, Constant::Integer(parsed_value));
+            constant_args.insert(
+                0,
+                self.pool.add(Term::Const(Constant::Integer(parsed_value))),
+            );
             return Ok((ParamOperator::BvConst, constant_args));
         }
 
@@ -1439,7 +1442,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
         let mut constant_args = Vec::new();
         for arg in args {
             if let Some(i) = arg.as_signed_integer() {
-                constant_args.push(Constant::Integer(i));
+                constant_args.push(self.pool.add(Term::Const(Constant::Integer(i))));
             } else {
                 return Err(Error::Parser(
                     ParserError::ExpectedIntegerConstant(arg.clone()),
@@ -1467,7 +1470,7 @@ impl<'a, R: BufRead> Parser<'a, R> {
     fn make_indexed_op(
         &mut self,
         op: ParamOperator,
-        op_args: Vec<Constant>,
+        op_args: Vec<Rc<Term>>,
         args: Vec<Rc<Term>>,
     ) -> Result<Rc<Term>, ParserError> {
         let sorts: Vec<_> = args.iter().map(|t| self.pool.sort(t)).collect();
@@ -1497,7 +1500,11 @@ impl<'a, R: BufRead> Parser<'a, R> {
                     return Err(ParserError::ExpectedBvSort(sorts[0].clone()));
                 }
                 for arg in &op_args {
-                    SortError::assert_eq(&Sort::Int, &arg.sort())?;
+                    if let Term::Const(c) = arg.as_ref() {
+                        SortError::assert_eq(&Sort::Int, &c.sort())?;
+                    } else {
+                        return Err(ParserError::ExpectedIntegerConstant(arg.clone()));
+                    }
                 }
                 assert_indexed_op_args_value(&op_args, 0..)?;
                 let i = op_args[0].as_integer().unwrap();
@@ -1519,7 +1526,11 @@ impl<'a, R: BufRead> Parser<'a, R> {
             | ParamOperator::SignExtend => {
                 assert_num_args(&op_args, 1)?;
                 assert_num_args(&args, 1)?;
-                SortError::assert_eq(&Sort::Int, &op_args[0].sort())?;
+                if let Term::Const(c) = op_args[0].as_ref() {
+                    SortError::assert_eq(&Sort::Int, &c.sort())?;
+                } else {
+                    return Err(ParserError::ExpectedIntegerConstant(op_args[0].clone()));
+                }
                 if !matches!(sorts[0], Sort::BitVec(_)) {
                     return Err(ParserError::ExpectedBvSort(sorts[0].clone()));
                 }
@@ -1528,7 +1539,11 @@ impl<'a, R: BufRead> Parser<'a, R> {
             ParamOperator::RePower => {
                 assert_num_args(&op_args, 1)?;
                 assert_num_args(&args, 1)?;
-                SortError::assert_eq(&Sort::Int, &op_args[0].sort())?;
+                if let Term::Const(c) = op_args[0].as_ref() {
+                    SortError::assert_eq(&Sort::Int, &c.sort())?;
+                } else {
+                    return Err(ParserError::ExpectedIntegerConstant(op_args[0].clone()));
+                }
                 SortError::assert_eq(&Sort::RegLan, sorts[0])?;
                 assert_indexed_op_args_value(&op_args, 0..)?;
             }
@@ -1536,17 +1551,17 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 assert_num_args(&op_args, 2)?;
                 assert_num_args(&args, 1)?;
                 for arg in &op_args {
-                    SortError::assert_eq(&Sort::Int, &arg.sort())?;
+                    if let Term::Const(c) = arg.as_ref() {
+                        SortError::assert_eq(&Sort::Int, &c.sort())?;
+                    } else {
+                        return Err(ParserError::ExpectedIntegerConstant(arg.clone()));
+                    }
                 }
                 SortError::assert_eq(&Sort::RegLan, sorts[0])?;
                 assert_indexed_op_args_value(&op_args, 0..)?;
             }
             ParamOperator::ArrayConst => return Err(ParserError::InvalidIndexedOp(op.to_string())),
         }
-        let op_args = op_args
-            .into_iter()
-            .map(|c| self.pool.add(Term::Const(c)))
-            .collect();
         Ok(self.pool.add(Term::ParamOp { op, op_args, args }))
     }
 


### PR DESCRIPTION
This is in preparation for supporting datatypes in Carcara, where we will deal with indexed operators whose arguments are not only constants.