### PR TITLE
[polyeq] Updates to handle rational constants

### DIFF
--- a/carcara/src/ast/polyeq.rs
+++ b/carcara/src/ast/polyeq.rs
@@ -497,7 +497,15 @@ impl PolyeqComparable for Rc<Term> {
 impl PolyeqComparable for Term {
     fn eq(comp: &mut Polyeq, a: &Self, b: &Self) -> bool {
         match (a, b) {
-            (Term::Const(a), Term::Const(b)) => a == b,
+            (Term::Const(a1), Term::Const(b1)) => match (a1, b1) {
+                (Constant::Real(r1), Constant::Integer(i2)) if r1.is_integer() => {
+                    r1.numer().clone() == i2.clone()
+                }
+                (Constant::Integer(i1), Constant::Real(r2)) if r2.is_integer() => {
+                    i1.clone() == r2.numer().clone()
+                }
+                _ => a == b,
+            },
             (Term::Var(a, a_sort), Term::Var(b, b_sort)) if comp.de_bruijn_map.is_some() => {
                 // If we are checking for alpha-equivalence, and we encounter two variables, we
                 // check that they are equivalent using the De Bruijn map
@@ -550,9 +558,19 @@ impl PolyeqComparable for Term {
                 // if they are the same
                 match (args[0].as_ref(), args[1].as_ref()) {
                     (Term::Const(Constant::Real(r1)), Term::Const(Constant::Real(r2)))
-                        if r1.is_integer() && r2.is_integer() =>
+                        if r.is_positive() && r1.is_integer() && r2.is_integer() =>
                     {
                         Rational::from((r1.numer(), r2.numer())) == r.clone()
+                    }
+                    (Term::Op(Operator::Sub, args), Term::Const(Constant::Integer(r2)))
+                    | (Term::Const(Constant::Integer(r2)), Term::Op(Operator::Sub, args))
+                        if r.is_negative() && args.len() == 1 =>
+                    {
+                        if let Term::Const(Constant::Integer(r1)) = args[0].as_ref() {
+                            Rational::from((r1, r2)) == r.clone().abs()
+                        } else {
+                            false
+                        }
                     }
                     _ => false,
                 }
@@ -563,6 +581,8 @@ impl PolyeqComparable for Term {
             {
                 if let Term::Const(Constant::Integer(i2)) = args[0].as_ref() {
                     i1.clone().abs() == i2.clone()
+                } else if let Term::Const(Constant::Real(r2)) = args[0].as_ref() {
+                    i1.clone().abs() == r2.numer().clone()
                 } else {
                     false
                 }


### PR DESCRIPTION
This is to further handle differences between assertions and assumptions containing `(/ 1 2)` vs `1/2` for example, but involving negations and whatnot.