### PR TITLE
Implement the rule `pbblast_bvsge`

### DIFF
--- a/carcara/src/checker/rules/pb_blasting.rs
+++ b/carcara/src/checker/rules/pb_blasting.rs
@@ -242,8 +242,21 @@ pub fn pbblast_bvsgt(RuleArgs { .. }: RuleArgs) -> RuleResult {
 ///
 /// The expected shape is:
 ///    `(= (bvsge x y) (>= (+ (- x_sum (* 2^(n-1) x_n-1))) (- (* 2^(n-1) y_n-1) y_sum)) 0))`
-pub fn pbblast_bvsge(RuleArgs { .. }: RuleArgs) -> RuleResult {
-    Err(CheckerError::Unspecified)
+pub fn pbblast_bvsge(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
+    let ((x, y), (((sum_x, sign_x), (sign_y, sum_y)), _)) = match_term_err!((= (bvsge x y) (>= (+ (- sum_x sign_x) (- sign_y sum_y)) 0)) = &conclusion[0])?;
+
+    // Get the summation lists
+    let sum_x = get_pbsum(sum_x);
+    let sum_y = get_pbsum(sum_y);
+
+    // Get bit width of `x`
+    let n = get_bit_width(x, pool)?;
+
+    // Check the sign terms
+    check_pbblast_signed_relation(n, sign_x, x)?;
+    check_pbblast_signed_relation(n, sign_y, y)?;
+
+    check_pbblast_constraint(pool, x, y, sum_x, sum_y)
 }
 
 /// Implements the signed-less-equal rule.
@@ -1636,10 +1649,286 @@ mod tests {
     fn pbblast_bvsgt_4() {}
 
     #[test]
-    fn pbblast_bvsge_2() {}
+    fn pbblast_bvsge_2() {
+        test_cases! {
+            definitions = "
+            (declare-const x2 (_ BitVec 2))
+            (declare-const y2 (_ BitVec 2))
+        ",
+
+            // Using explicit multiplication everywhere.
+            "bvsge on two bits with explicit multiplication" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))   ; x sum
+                                            (* 2 ((_ @int_of 1) x2))   ; x sign
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))   ; y sign
+                                            (* 1 ((_ @int_of 0) y2))   ; y sum
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: true,
+            }
+
+            // Omitting the explicit multiplication by 1 in the sum parts.
+            "bvsge on two bits omitting multiplication by 1 in sum parts" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            ((_ @int_of 0) x2)         ; x sum omitted "* 1"
+                                            (* 2 ((_ @int_of 1) x2)) 
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))         
+                                            ((_ @int_of 0) y2)         ; y sum omitted "* 1"
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: true,
+            }
+
+            // Wrong scalar of the sign bit
+            "bvsge on two bits wrong scalar of the sign bit of y" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))
+                                            (* 1 ((_ @int_of 1) x2))   ; should be * 2
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "bvsge on two bits wrong scalar of the sign bit of y" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))
+                                            (* 2 ((_ @int_of 1) x2))    
+                                        )
+                                        (-
+                                            (* 1 ((_ @int_of 1) y2))   ; should be * 2
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            // Wrong indexing of the sign bit
+            "bvsge on two bits wrong indexing of the sign bit of x" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))
+                                            (* 2 ((_ @int_of 0) x2))   ; should be (_ @int_of 1)
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "bvsge on two bits wrong indexing of the sign bit of y" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))
+                                            (* 2 ((_ @int_of 1) x2))    
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 0) y2))   ; should be (_ @int_of 1)
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "bvsge on two bits wrong bitvector of the sign bit of y" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))
+                                            (* 2 ((_ @int_of 1) x2))    
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) x2))   ; should be y2
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "bvsge on two bits wrong bitvector of the sign bit of x" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 0) x2))
+                                            (* 2 ((_ @int_of 1) y2))   ; should be x2
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))         
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            // Wrong indexing of the summation term
+            "bvsge on two bits with wrong indexing of the summation term" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (* 1 ((_ @int_of 1) x2))   ; should be "@int_of 0"
+                                            (* 2 ((_ @int_of 1) x2))
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))
+                                            (* 1 ((_ @int_of 0) y2))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "Trailing Zero" {
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (+ (* 1 ((_ @int_of 0) x2)) 0)   ; x sum
+                                            (* 2 ((_ @int_of 1) x2))         ; x sign
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))         ; y sign
+                                            (+ (* 1 ((_ @int_of 0) y2)) 0)   ; y sum
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+
+                r#"(step t1 (cl (= (bvsge x2 y2)
+                                (>= (+
+                                        (-
+                                            (+ ((_ @int_of 0) x2) 0)         ; x sum omitted "* 1"
+                                            (* 2 ((_ @int_of 1) x2)) 
+                                        )
+                                        (-
+                                            (* 2 ((_ @int_of 1) y2))         
+                                            (+ ((_ @int_of 0) y2) 0)         ; y sum omitted "* 1"
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+        }
+    }
 
     #[test]
-    fn pbblast_bvsge_4() {}
+    fn pbblast_bvsge_4() {
+        test_cases! {
+            definitions = "
+            (declare-const x4 (_ BitVec 4))
+            (declare-const y4 (_ BitVec 4))
+        ",
+            // Using explicit multiplication everywhere.
+            "bvsge on 4 bits with explicit multiplication" {
+                r#"(step t1 (cl (= (bvsge x4 y4)
+                                (>= (+
+                                        (-
+                                            (+ (* 1 ((_ @int_of 0) x4))
+                                               (* 2 ((_ @int_of 1) x4))
+                                               (* 4 ((_ @int_of 2) x4)))
+                                            (* 8 ((_ @int_of 3) x4)))
+                                        (-
+                                            (* 8 ((_ @int_of 3) y4))
+                                            (+ (* 1 ((_ @int_of 0) y4))
+                                               (* 2 ((_ @int_of 1) y4))
+                                               (* 4 ((_ @int_of 2) y4)))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: true,
+            }
+
+            // Omitting explicit multiplication by 1 in the sum parts.
+            "bvsge on 4 bits omitting multiplication by 1 in sum parts" {
+                r#"(step t1 (cl (= (bvsge x4 y4)
+                                (>= (+
+                                        (-
+                                            (+ ((_ @int_of 0) x4)            ; omit "* 1"
+                                               (* 2 ((_ @int_of 1) x4))
+                                               (* 4 ((_ @int_of 2) x4)))
+                                            (* 8 ((_ @int_of 3) x4)))
+                                        (-
+                                            (* 8 ((_ @int_of 3) y4))
+                                            (+ ((_ @int_of 0) y4)            ; omit "* 1"
+                                               (* 2 ((_ @int_of 1) y4))
+                                               (* 4 ((_ @int_of 2) y4)))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: true,
+            }
+
+            "wrong indexed bvsge on 4 bits with explicit multiplication" {
+                r#"(step t1 (cl (= (bvsge x4 y4)
+                                (>= (+
+                                        (-
+                                            (+ (* 8 ((_ @int_of 0) x4)) ; wrong coefficients
+                                               (* 4 ((_ @int_of 1) x4))
+                                               (* 2 ((_ @int_of 2) x4)))
+                                            (* 1 ((_ @int_of 3) x4)))
+                                        (-
+                                            (* 8 ((_ @int_of 3) y4))
+                                            (+ (* 1 ((_ @int_of 0) y4))
+                                               (* 2 ((_ @int_of 1) y4))
+                                               (* 4 ((_ @int_of 2) y4)))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "bvsge on four bits wrong scalar of the sign bit" {
+                            r#"(step t1 (cl (= (bvsge x4 y4)
+                                (>= (+
+                                        (-
+                                            (+ (* 1 ((_ @int_of 0) x4))
+                                               (* 2 ((_ @int_of 1) x4))
+                                               (* 4 ((_ @int_of 2) x4)))
+                                            (* 4 ((_ @int_of 3) x4)))    ; should be * 8
+                                        (-
+                                            (* 8 ((_ @int_of 3) y4))
+                                            (+ (* 1 ((_ @int_of 0) y4))
+                                               (* 2 ((_ @int_of 1) y4))
+                                               (* 4 ((_ @int_of 2) y4)))
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+
+            "Trailing Zero" {
+                r#"(step t1 (cl (= (bvsge x4 y4)
+                                (>= (+
+                                        (-
+                                            (+ (* 1 ((_ @int_of 0) x4))
+                                               (* 2 ((_ @int_of 1) x4))
+                                               (* 4 ((_ @int_of 2) x4))
+                                               0)
+                                            (* 8 ((_ @int_of 3) x4)))
+                                        (-
+                                            (* 8 ((_ @int_of 3) y4))
+                                            (+ (* 1 ((_ @int_of 0) y4))
+                                               (* 2 ((_ @int_of 1) y4))
+                                               (* 4 ((_ @int_of 2) y4))
+                                               0)
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+
+                r#"(step t1 (cl (= (bvsge x4 y4)
+                                (>= (+
+                                        (-
+                                            (+ ((_ @int_of 0) x4)            ; omit "* 1"
+                                               (* 2 ((_ @int_of 1) x4))
+                                               (* 4 ((_ @int_of 2) x4))
+                                               0)
+                                            (* 8 ((_ @int_of 3) x4)))
+                                        (-
+                                            (* 8 ((_ @int_of 3) y4))
+                                            (+ ((_ @int_of 0) y4)            ; omit "* 1"
+                                               (* 2 ((_ @int_of 1) y4))
+                                               (* 4 ((_ @int_of 2) y4))
+                                               0)
+                                        )
+                                    ) 0))) :rule pbblast_bvsge)"#: false,
+            }
+        }
+    }
 
     #[test]
     fn pbblast_bvsle_2() {}


### PR DESCRIPTION
This PR adds the implementation of the `pbblast_bvsge` rule for checking `>=` between _signed_ bitvectors using pseudo-Boolean blasting. 

## Key highlights:
- Uses the helper `check_pbblast_signed_relation`
- Includes test cases covering:
    - 2-bit, and 4-bit bitvectors