### PR TITLE
Implement rule `cp_literal`

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -495,6 +495,7 @@ impl<'c> ProofChecker<'c> {
             "cp_multiplication" => cutting_planes::cp_multiplication,
             "cp_division" => cutting_planes::cp_division,
             "cp_saturation" => cutting_planes::cp_saturation,
+            "cp_literal" => cutting_planes::cp_literal,
 
             "string_decompose" => strings::string_decompose,
             "string_length_pos" => strings::string_length_pos,

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -1,4 +1,6 @@
-use super::{assert_clause_len, assert_num_args, assert_num_premises, RuleArgs, RuleResult, Term};
+use super::{
+    assert_clause_len, assert_eq, assert_num_args, assert_num_premises, RuleArgs, RuleResult, Term,
+};
 use crate::checker::error::CheckerError;
 use crate::checker::Rc;
 use rug::Integer;
@@ -349,4 +351,13 @@ pub fn cp_saturation(RuleArgs { premises, args, conclusion, .. }: RuleArgs) -> R
     }
 
     Ok(())
+}
+
+pub fn cp_literal(RuleArgs { args, conclusion, .. }: RuleArgs) -> RuleResult {
+    assert_num_args(args, 1)?;
+    let ((_, l), _) = match_term_err!((>= (* 1 l) 0) = &conclusion[0])?;
+    // ? Either we assert Int l is 0 or 1
+    // ? or we need to fix it to be a variable?
+    // TODO: Prevent concluding (>= (* 1 -1) 0)
+    assert_eq(l, &args[0])
 }

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -279,3 +279,33 @@ fn cp_saturation() {
 
     }
 }
+
+#[test]
+fn cp_literal() {
+    test_cases! {
+        definitions = "
+            (declare-fun l () Int)
+            (define-fun neg_l () Int (- 1 l))
+        ",
+        "cp_literal correctly applied" {
+            r#"(step t1 (cl (>= (* 1 l) 0)) :rule cp_literal :args (l))"#: true,
+            r#"(step t1 (cl (>= (* 1 neg_l) 0)) :rule cp_literal :args (neg_l))"#: true,
+        }
+        "cp_literal invalid (coefficients)" {
+            r#"(step t1 (cl (>= (* 1 l) 0)) :rule cp_literal :args ((* 2 l)))"#: false,
+            r#"(step t1 (cl (>= (* 2 l) 0)) :rule cp_literal :args ((* 2 l)))"#: false,
+
+            r#"(step t1 (cl (>= (* 1 neg_l) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: false,
+            r#"(step t1 (cl (>= (* 2 neg_l) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: false,
+
+            // Should this be wrong?    v- this can be achieved using cp_multiplication later
+            r#"(step t1 (cl (>= (* 1 (* 2 l)) 0)) :rule cp_literal :args ((* 2 l)))"#: false,
+            r#"(step t1 (cl (>= (* 1 (* 2 neg_l)) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: false,
+        }
+        "cp_literal invalid (number of args)" {
+            r#"(step t1 (cl (>= (* 1 l) 0)) :rule cp_literal)"#: false,
+            r#"(step t1 (cl (>= (* 1 l) 0)) :rule cp_literal :args (l neg_l))"#: false,
+            r#"(step t1 (cl (>= (* 1 neg_l) 0)) :rule cp_literal :args (neg_l l))"#: false,
+        }
+    }
+}

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -288,7 +288,9 @@ fn cp_literal() {
             (define-fun neg_l () Int (- 1 l))
         ",
         "cp_literal correctly applied" {
+            r#"(step t1 (cl (>= l 0)) :rule cp_literal :args (l))"#: true,
             r#"(step t1 (cl (>= (* 1 l) 0)) :rule cp_literal :args (l))"#: true,
+            r#"(step t1 (cl (>= neg_l 0)) :rule cp_literal :args (neg_l))"#: true,
             r#"(step t1 (cl (>= (* 1 neg_l) 0)) :rule cp_literal :args (neg_l))"#: true,
         }
         "cp_literal invalid (coefficients)" {
@@ -298,9 +300,9 @@ fn cp_literal() {
             r#"(step t1 (cl (>= (* 1 neg_l) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: false,
             r#"(step t1 (cl (>= (* 2 neg_l) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: false,
 
-            // Should this be wrong?    v- this can be achieved using cp_multiplication later
-            r#"(step t1 (cl (>= (* 1 (* 2 l)) 0)) :rule cp_literal :args ((* 2 l)))"#: false,
-            r#"(step t1 (cl (>= (* 1 (* 2 neg_l)) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: false,
+            // ! THIS SHOULD BE AVOIDED WHEN l is a PSEUDO BOOLEAN
+            r#"(step t1 (cl (>= (* 1 (* 2 l)) 0)) :rule cp_literal :args ((* 2 l)))"#: true,
+            r#"(step t1 (cl (>= (* 1 (* 2 neg_l)) 0)) :rule cp_literal :args ((* 2 neg_l)))"#: true,
         }
         "cp_literal invalid (number of args)" {
             r#"(step t1 (cl (>= (* 1 l) 0)) :rule cp_literal)"#: false,


### PR DESCRIPTION
Implementation of the rule `cp_literal`, described [here](https://gitlab.uliege.be/verit/alethe/-/jobs/196565/artifacts/browse), page 54. "A literal 𝑙 being greater or equal to zero can be introduced at any time"

This rule is true when we suppose $l$ is either a pseudo boolean variable or the negation of one `(- 1 l)`
