### PR TITLE
Implement the rule `cp_normalize`

### DIFF
--- a/carcara/src/ast/macros.rs
+++ b/carcara/src/ast/macros.rs
@@ -278,16 +278,17 @@ macro_rules! build_term {
     ($pool:expr, true) => { $pool.bool_true() };
     ($pool:expr, false) => { $pool.bool_false() };
     ($pool:expr, (let $name:ident $sort:ident)) => {{
-        let sort = $pool.add($crate::ast::Term::Sort(Sort::$sort));
+        let sort = $pool.add($crate::ast::Term::Sort($crate::checker::Sort::$sort));
         $pool.add($crate::ast::Term::new_var(stringify!($name), sort))
     }};
     ($pool:expr, (choice (($z:literal $sort:ident)) $arg:tt)) => {{
-        let sort = $pool.add($crate::ast::Term::Sort(Sort::$sort));
+        let sort = $pool.add($crate::ast::Term::Sort($crate::checker::Sort::$sort));
         let bindings = $crate::ast::BindingList(vec![($z.into(), sort)]);
         let body = build_term!($pool, $arg);
         $pool.add(Term::Binder(Binder::Choice, bindings, body))
     }};
     ($pool:expr, $int:literal) => { $pool.add(Term::Const($crate::ast::Constant::Integer($int.into()))) };
+    ($pool:expr, (const $name:ident)) => { $pool.add(Term::Const($crate::ast::Constant::Integer($name))) };
     ($pool:expr, {$terminal:expr}) => { $terminal };
     ($pool:expr, ((_ $indexed_op:tt $($op_args:tt)+) $($args:tt)+)) => {{
         let term = $crate::ast::Term::ParamOp {

--- a/carcara/src/checker/error.rs
+++ b/carcara/src/checker/error.rs
@@ -121,6 +121,9 @@ pub enum CheckerError {
     #[error("expected term '{0}' to be a boolean constant")]
     ExpectedAnyBoolConstant(Rc<Term>),
 
+    #[error("expected term '{0}' to be an integer constant")]
+    ExpectedAnyIntegerConstant(Rc<Term>),
+
     #[error("expected term '{0}' to be a string constant of length one")]
     ExpectedStringConstantOfLengthOne(Rc<Term>),
 

--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -495,6 +495,7 @@ impl<'c> ProofChecker<'c> {
             "cp_multiplication" => cutting_planes::cp_multiplication,
             "cp_division" => cutting_planes::cp_division,
             "cp_saturation" => cutting_planes::cp_saturation,
+            "cp_normalize" => cutting_planes::cp_normalize,
 
             "string_decompose" => strings::string_decompose,
             "string_length_pos" => strings::string_length_pos,

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -1,4 +1,6 @@
-use super::{assert_clause_len, assert_num_args, assert_num_premises, RuleArgs, RuleResult, Term};
+use super::{
+    assert_clause_len, assert_eq, assert_num_args, assert_num_premises, RuleArgs, RuleResult, Term,
+};
 use crate::checker::error::CheckerError;
 use crate::checker::Rc;
 use rug::Integer;
@@ -347,6 +349,36 @@ pub fn cp_saturation(RuleArgs { premises, args, conclusion, .. }: RuleArgs) -> R
             );
         }
     }
+
+    Ok(())
+}
+
+pub fn cp_normalize(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+    let (lhs, rhs) = match_term_err!((= a b) = &conclusion[0])?;
+
+    // TODO: check rhs is normalized
+    let (pb_sum, constant) = match_term_err!((>= pb_sum constant) = rhs)?;
+    rassert!(
+        constant.is_const(),
+        CheckerError::ExpectedAnyIntegerConstant(constant.clone())
+    );
+
+    // Push negations from lhs to find rhs
+
+    // What relation is involved?
+    let relation = if let Some(k) = match_term!((>= a b) = lhs) {
+        ">="
+    } else if let Some(k) = match_term!((= a b ) = lhs) {
+        "="
+    } else if let Some(k) = match_term!((<= a b ) = lhs) {
+        "<="
+    } else if let Some(k) = match_term!((< a b ) = lhs) {
+        "<"
+    } else if let Some(k) = match_term!((> a b ) = lhs) {
+        ">"
+    } else {
+        "b"
+    };
 
     Ok(())
 }

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -356,12 +356,12 @@ pub fn cp_saturation(RuleArgs { premises, args, conclusion, .. }: RuleArgs) -> R
 pub fn cp_normalize(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     let (lhs, rhs) = match_term_err!((= a b) = &conclusion[0])?;
 
-    // TODO: check rhs is normalized
-    let (pb_sum, constant) = match_term_err!((>= pb_sum constant) = rhs)?;
-    rassert!(
-        constant.is_const(),
-        CheckerError::ExpectedAnyIntegerConstant(constant.clone())
-    );
+    // TODO: check rhs is normalized (or and A B) where A and B are normalized
+    // let (pb_sum, constant) = match_term_err!((>= pb_sum constant) = rhs)?;
+    // rassert!(
+    //     constant.is_const(),
+    //     CheckerError::ExpectedAnyIntegerConstant(constant.clone())
+    // );
 
     // Push negations from lhs to find rhs
 

--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -389,6 +389,11 @@ pub fn cp_literal(RuleArgs { pool, args, conclusion, .. }: RuleArgs) -> RuleResu
     ))
 }
 
+fn negate_sum(sum: &Vec<Rc<Term>>) -> Vec<Rc<Term>> {
+    // todo!("This function will negate all coefficients of this term")
+    vec![]
+}
+
 pub fn cp_normalize(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
     let (lhs, rhs) = match_term_err!((= lhs rhs) = &conclusion[0])?;
 
@@ -455,5 +460,32 @@ pub fn cp_normalize(RuleArgs { pool, conclusion, .. }: RuleArgs) -> RuleResult {
     println!("VARS:\t\t\t\t\t\t\t{vars:?}");
     println!("CONSTANT:\t\t\t\t\t\t{constant:?}");
 
+    // Special variables when "=" uses two constraints
+    let mut vars2: Vec<Rc<Term>> = vec![];
+    let mut constant2: Integer = 0.into();
+
+    // Eliminate other relations
+    match rel.as_str() {
+        ">" => constant += 1,
+        "<" => {
+            vars = negate_sum(&vars);
+            constant = 1 - constant;
+        }
+        "<=" => {
+            vars = negate_sum(&vars);
+            constant = -constant;
+        }
+        "=" => {
+            vars2 = negate_sum(&vars);
+            constant2 = -constant.clone();
+        }
+        _ => (),
+    }
+    println!("VARS AFTER ELIM:\t\t\t\t\t\t\t{vars:?}");
+    println!("CONSTANT AFTER ELIM:\t\t\t\t\t\t{constant:?}");
+    println!("VARS2 AFTER ELIM:\t\t\t\t\t\t\t{vars2:?}");
+    println!("CONSTANT2 AFTER ELIM:\t\t\t\t\t\t{constant2:?}");
+
+    // TODO: Push Negations
     Ok(())
 }

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -338,6 +338,8 @@ fn cp_normalize() {
         }
         "Other relations are eliminated" {
             r#"(step t1 (cl (= (<= a 0) (>= (- 1 a) 1))) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (= (<= (- 1 a) 0) (>= a 1))) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (= (<= (* -1 a) 0) (>= a 0))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (> a 0) (>= a 1))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (< a 0) (>= (* -1 a) 2))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (= a 0) (and (>= a 0) (>= (* -1 a) 1)))) :rule cp_normalize)"#: true,
@@ -355,6 +357,12 @@ fn cp_normalize() {
         }
         "Invalid relations" {
             r#"(step t1 (cl (= (and true true) (>= a 0))) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (not (= (>= a 1) (>= a 0)))) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (not (= (+ a 1) (+ 1 a)))) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (= (<= (* -1 a 1) 0) (>= a 0))) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (= (>= (+ a 1) 0) (>= a 0))) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (= (= a 0 0) (and (>= a 0) (>= (* -1 a) 1)))) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (= true (>= a 0))) :rule cp_normalize)"#: false,
         }
     }
 }

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -305,9 +305,9 @@ fn cp_normalize() {
         }
         "Other relations are eliminated" {
             r#"(step t1 (cl (= (<= a 0) (>= (- 1 a) 1))) :rule cp_normalize)"#: true,
-            r#"(step t1 (cl (= (> a 0) (>= a 1) :rule cp_normalize)"#: true,
-            r#"(step t1 (cl (= (< a 0) (>= (* -1 a) 2) :rule cp_normalize)"#: true,
-            r#"(step t1 (cl (= (= a 0) (and (>= a 0) (>= (* -1 a) 1)) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (= (> a 0) (>= a 1))) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (= (< a 0) (>= (* -1 a) 2))) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (= (= a 0) (and (>= a 0) (>= (* -1 a) 1)))) :rule cp_normalize)"#: true,
         }
         "Constants are moved to the right" {
             r#"(step t1 (cl (= (>= (+ a 1) 0) (>= a -1))) :rule cp_normalize)"#: true,

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -351,5 +351,8 @@ fn cp_normalize() {
             r#"(step t1 (cl (= (>= a (+ b c)) (>= (+ a (- 1 b) (- 1 c)) 2))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (>= (+ a 2) (+ b c)) (>= (+ a (- 1 b) (- 1 c)) 0))) :rule cp_normalize)"#: true,
         }
+        "Invalid relations" {
+            r#"(step t1 (cl (= (and true true) (>= a 0))) :rule cp_normalize)"#: false,
+        }
     }
 }

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -330,6 +330,7 @@ fn cp_normalize() {
             r#"(step t1 (cl (= (>= (+ (* 2 a) (* 3 b)) 0) (>= (+ (* 2 a) (* 3 b)) 0))) :rule cp_normalize)"#: true,
         }
         "Negative coefficient is pushed" {
+            r#"(step t1 (cl (= (>= (* -1 a) 0) (>= (* 1 (- 1 a)) 1))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (>= (* -1 a) 0) (>= (- 1 a) 1))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (>= (* -5 a) 0) (>= (* 5 (- 1 a)) 5))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (>= (+ (* -1 a) (* -3 b)) 0) (>= (+ (- 1 a) (* 3 (- 1 b))) 4))) :rule cp_normalize)"#: true,

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -340,6 +340,7 @@ fn cp_normalize() {
             r#"(step t1 (cl (= (> a 0) (>= a 1))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (< a 0) (>= (* -1 a) 2))) :rule cp_normalize)"#: true,
             r#"(step t1 (cl (= (= a 0) (and (>= a 0) (>= (* -1 a) 1)))) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (= (= (* 1 a) 0) (and (>= a 0) (>= (* -1 a) 1)))) :rule cp_normalize)"#: true,
         }
         "Constants are moved to the right" {
             r#"(step t1 (cl (= (>= (+ a 1) 0) (>= a -1))) :rule cp_normalize)"#: true,


### PR DESCRIPTION
This rule simplifies a linear relation term by applying equivalence-preserving transformations until a fixed point called **normalized form** is reached:

$$\huge \sum_i{a_i l_i} \ge A $$

Where we have:
- constant $A \in \mathbb{N}$
- coefficients $a_i \in \mathbb{N}$
- literals $l_i: x_i\ \text{or}\ \overline{x_i}\ (\text{where } x_i + \overline{x_i} = 1)$
- variables $x_i$ are _pseudo-boolean_ i.e. $0$ or $1$

A high-level description of this rule is available at page 54, rule 105 of the [spec](https://gitlab.uliege.be/verit/alethe/-/jobs/196591/artifacts/file/specification.pdf).

## Other contributions
- Extend the `build_term` macro to introduce `const x`, when `x` is `Integer`.
- Standardize the helper function `split_summation`, that is used both in `cutting_planes.rs` and `pb_blasting.rs`
- The helpers `negate_term` `push_negation` `flatten_mul` `pack_summation` `check_equivalent_inequalities` all were written to make the rule `cp_normalize` more manageable, since it takes multiple steps that repeat themselves symmetrically.
- In addition to creating the tests, I also ran the tool [cargo-llvm-cov](https://lib.rs/crates/cargo-llvm-cov) to check what regions of the code were being covered by the tests, and it was important to reveal some test conditions I hadn't thought about before.