### PR TITLE
Patch: Validate vars list length in `check_pb_inequalities`

### DIFF
--- a/carcara/src/checker/rules/cutting_planes.rs
+++ b/carcara/src/checker/rules/cutting_planes.rs
@@ -574,6 +574,15 @@ fn check_pb_inequalities(
     vars_r: &[CoeffTimesVar],
     kr: &Integer,
 ) -> RuleResult {
+    rassert!(
+        vars_l.len() == vars_r.len(),
+        CheckerError::Explanation(format!(
+            "List of variables should have same length, got {} and {}",
+            vars_l.len(),
+            vars_r.len()
+        ))
+    );
+
     for (var_l, var_r) in vars_l.iter().zip(vars_r) {
         rassert!(
             var_l == var_r,

--- a/carcara/tests/rules/cutting_planes.rs
+++ b/carcara/tests/rules/cutting_planes.rs
@@ -411,5 +411,25 @@ fn cp_normalize() {
                     )) :rule cp_normalize)"#: true,
 
         }
+        "Validates variable list length" {
+            r#"(step t1 (cl (=
+                (= (- (+ (* 1 a) (* 2 b)) (+ (* 1 1) (* 2 0))) 0)
+                (and (>= (+ a (* 2 b) (- 1 1) (* 2 (- 1 0))) 3)
+                     (>= (+ (- 1 a) (* 2 (- 1 b)) (* 1 1) (* 2 0)) 3)
+                )
+            )) :rule cp_normalize)"#: true,
+            r#"(step t1 (cl (=
+                (= (- (+ (* 1 a) (* 2 b)) (+ (* 1 1) (* 2 0))) 0)
+                (and (>= a 3)
+                     (>= (- 1 a) 3)
+                )
+            )) :rule cp_normalize)"#: false,
+            r#"(step t1 (cl (=
+                (= (- (+ (* 1 a) (* 2 b)) (+ (* 1 1) (* 2 0))) 0)
+                (and (>= (+ a (* 2 b)) 3)
+                     (>= (+ (- 1 a) (* 2 (- 1 b))) 3)
+                )
+            )) :rule cp_normalize)"#: false,
+        }
     }
 }


### PR DESCRIPTION
While using the rule `cp_normalize` I realized the length of the variables list was not being validated, what introduced issues if variables of the left hand side are omitted in the right hand side. 
In this sense I added tests to check the behavior and the fix in the `check_pb_inequalities` helper method.