### PR TITLE
Implement the rule `pbblast_bvxor_ith_bit`

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -488,6 +488,7 @@ impl<'c> ProofChecker<'c> {
             "pbblast_pbbconst" => pb_blasting::pbblast_pbbconst,
             "pbblast_bvxor" => pb_blasting::pbblast_bvxor,
             "pbblast_bvand" => pb_blasting::pbblast_bvand,
+            "pbblast_bvxor_ith_bit" => pb_blasting::pbblast_bvxor_ith_bit,
             "pbblast_bvand_ith_bit" => pb_blasting::pbblast_bvand_ith_bit,
 
             // cutting planes rules


### PR DESCRIPTION
Implementation of the rule `pbblast_bvxor_ith_bit`, described as Rule 119 of the [specification](https://gitlab.uliege.be/verit/alethe/-/jobs/197680/artifacts/browse), page 59.

- This rule is much alike the `pbblast_bvand_ith_bit` rule, only taking different constraints out of the exclusive or operator
