### PR TITLE
Extend slice to work in subproofs and produce problem files

### DIFF
--- a/carcara/src/ast/printer.rs
+++ b/carcara/src/ast/printer.rs
@@ -30,6 +30,18 @@ pub fn print_proof(
     AlethePrinter::new(pool, prelude, use_sharing, &mut stdout).write_proof(proof)
 }
 
+// Like print_proof, but to write to a string, not stdout
+pub fn proof_to_string(
+    pool: &mut PrimitivePool,
+    prelude: &ProblemPrelude,
+    proof: &Proof,
+    use_sharing: bool,
+) -> String {
+    let mut bytes = Vec::new();
+    let _ = AlethePrinter::new(pool, prelude, use_sharing, &mut bytes).write_proof(proof);
+    String::from_utf8(bytes).unwrap()
+}
+
 /// Given the conclusion clause of a `lia_generic` step, this method will write to `dest` the
 /// corresponding SMT problem instance.
 pub fn write_lia_smt_instance(
@@ -48,6 +60,30 @@ pub fn write_lia_smt_instance(
     // cannot use the GMP notation
     printer.smt_lib_strict = true;
     printer.write_lia_smt_instance(clause)
+}
+
+pub fn write_asserts(
+    pool: &mut PrimitivePool,
+    prelude: &ProblemPrelude,
+    dest: &mut dyn io::Write,
+    asserts: &Vec<Rc<Term>>,
+    use_sharing: bool,
+) -> io::Result<()> {
+    let mut printer = AlethePrinter::new(pool, prelude, use_sharing, dest);
+    // We have to override the default prefix "@p_" because symbols starting with "@" are reserved
+    // in SMT-LIB.
+    printer.term_sharing_variable_prefix = "p_";
+    // Since we are printing an SMT-LIB problem, we have to be
+    // compliant. For Carcara, this means that arithmetic constants
+    // cannot use the GMP notation
+    printer.smt_lib_strict = true;
+
+    for assertion in asserts {
+        write!(printer.inner, "(assert ")?;
+        assertion.print_with_sharing(&mut printer)?;
+        writeln!(printer.inner, ")")?;
+    }
+    Ok(())
 }
 
 trait PrintProof {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -649,7 +649,7 @@ fn slice_command(
     options: SliceCommandOptions,
 ) -> CliResult<(ast::Problem, ast::Proof, ast::PrimitivePool)> {
     use std::fs;
-    
+
     let (problem, proof) = get_instance(&options.input, false)?;
     let (problem, proof, mut pool) =
         parser::parse_instance(problem, proof, options.parsing.into())?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -655,9 +655,14 @@ fn slice_command(
         parser::parse_instance(problem, proof, options.parsing.into())?;
 
     let sliced = {
-        let (sliced_proof, sliced_problem_string, sliced_proof_string) =
-            slice(&problem, &proof, &options.from, &mut pool)
-                .ok_or(CliError::InvalidSliceId(options.from.clone()))?;
+        let (sliced_proof, sliced_problem_string, sliced_proof_string) = slice(
+            &problem,
+            &proof,
+            &options.from,
+            &mut pool,
+            options.max_distance.unwrap_or(0),
+        )
+        .ok_or(CliError::InvalidSliceId(options.from.clone()))?;
 
         let sliced_proof_file_name;
         let sliced_problem_file_name;


### PR DESCRIPTION
This pull request contains some extensions to slice.
- Most importantly, slice can now slice steps within subproofs.
- Slice now produces problem files. The output problem file contains the logic string and sort and function declarations of the original problem, an assertion corresponding to each assumption in the sliced problem, and `(assert false)` to be resolved trivially with `(cl (not false))`.
- Slice now writes its output to files specified by the user or to default paths in the working directory.