### PR TITLE
Emit parser error when assumption appears after step in subproof

### DIFF
--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -852,9 +852,12 @@ impl<'a, R: BufRead> Parser<'a, R> {
                         if stack.len() == 1 {
                             log::warn!("`assume` command '{}' appears after `step` commands", &id);
                         }
-                        // It is disallowed within subproofs. We will replace this warning with an error later.
+                        // It is disallowed within subproofs.
                         else {
-                            log::warn!("`assume` command '{}' appears after `step` commands within subproof", &id);
+                            return Err(Error::Parser(
+                                ParserError::AssumeAfterStepInSubproof(id),
+                                position,
+                            ));
                         }
                     }
 

--- a/carcara/src/parser/tests.rs
+++ b/carcara/src/parser/tests.rs
@@ -706,6 +706,25 @@ fn test_premises_in_subproofs() {
 }
 
 #[test]
+fn test_assumes_after_steps_in_subproofs() {
+    let mut p = PrimitivePool::new();
+    let bad_input = "
+        (assume h1 true)
+        (assume h2 true)
+        (anchor :step t3)
+        (step t3.t1 (cl) :rule rule-name :premises (h1 h2))
+        (assume h3 false)
+        (step t3.t2 (cl) :rule rule-name :premises (t3.t1 h1 h2))
+        (step t3 (cl) :rule rule-name :premises (h1 t3.t1 h2 t3.t2))
+    ";
+
+    assert!(matches!(
+        parse_proof_err(&mut p, bad_input),
+        Error::Parser(ParserError::AssumeAfterStepInSubproof(_), _)
+    ));
+}
+
+#[test]
 fn test_bitvectors() {
     let mut p = PrimitivePool::new();
     let cases = [

--- a/carcara/tests/rules/subproof.rs
+++ b/carcara/tests/rules/subproof.rs
@@ -15,11 +15,11 @@ fn subproof() {
 
             "(anchor :step t1)
             (assume t1.h1 p)
-            (step t1.t2 (cl) :rule hole)
-            (assume t1.h3 q)
+            (assume t1.h2 q)
+            (step t1.t3 (cl) :rule hole)
             (step t1.t4 (cl (= r s)) :rule hole)
             (step t1 (cl (not p) (not q) (= r s))
-                :rule subproof :discharge (t1.h1 t1.h3))": true,
+                :rule subproof :discharge (t1.h1 t1.h2))": true,
         }
         "Missing assumption" {
             "(anchor :step t1)


### PR DESCRIPTION
Now that the order of premises in subproofs [has been fixed](https://github.com/ufmg-smite/carcara/commit/93eb43a558c8311999d065516138bbc7c34482aa), I thought we could emit a parser error now as in the original version of PR #99 without testing errors (unless there's another reason to keep it as a warning).