### PR TITLE
Avoid subproofs concluding empty clause to confuse valid refutation check

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -154,7 +154,10 @@ impl<'c> ProofChecker<'c> {
                         self.context.pop();
                     }
 
-                    if step.clause.is_empty() {
+                    // Note that for the purpose of whether the proof of the input assumptions
+                    // concludes the empty clause this test must be made only when the context is
+                    // empty, i.e., when we are not in a subproof
+                    if step.clause.is_empty() && self.context.is_empty() {
                         self.reached_empty_clause = true;
                     }
                 }

--- a/carcara/tests/test_proof.rs
+++ b/carcara/tests/test_proof.rs
@@ -1,0 +1,34 @@
+use carcara::{checker::*, parser};
+
+fn run_test(problem: &str, proof: &str, expected_result: bool) {
+    let (problem, proof, mut pool) = parser::parse_instance(
+        problem.as_bytes(),
+        proof.as_bytes(),
+        parser::Config::default(),
+    )
+    .unwrap();
+
+    let got = ProofChecker::new(&mut pool, Config::new()).check(&problem, &proof);
+
+    assert_eq!(got.is_ok(), expected_result);
+}
+
+#[test]
+fn test_reached_empty_clause() {
+    run_test("(declare-const x Int)", "(step t1 (cl) :rule hole)", true);
+    run_test(
+        "",
+        "(anchor :step t0)
+                  (step t0.t1 (cl) :rule hole)
+                  (step t0 (cl false) :rule subproof)",
+        false,
+    );
+    run_test(
+        "",
+        "(anchor :step t0)
+                  (step t0.t1 (cl) :rule hole)
+                  (step t0 (cl false) :rule subproof)
+                  (step t1 (cl) :rule hole)",
+        true,
+    );
+}


### PR DESCRIPTION
Currently Carcara would accept a proof like this:
```
...
(anchor :step t0)
(step t0.t1 (cl) :rule hole)
(step t0 (cl false) :rule subproof)
```
The issue is that the check of whether a step concluding the empty clause has been reached is not guarding to having happened only in the context of a subproof. So it is currently possible to have a valid (or holey) refutation of a given input without deriving the empty clause from it but rather only in a subproof, with other assumptions.

@bpandreotti I wanted to add a test like the proof above, but I was uncertain how. Any suggestions?