### PR TITLE
Removing placeholder `check_rare` since it does not fail gracefully

### DIFF
--- a/carcara/src/checker/mod.rs
+++ b/carcara/src/checker/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 use error::{CheckerError, SubproofError};
 use indexmap::IndexSet;
 pub use parallel::{scheduler::Scheduler, ParallelProofChecker};
-use rules::{rare::check_rare, Premise, Rule, RuleArgs, RuleResult};
+use rules::{Premise, Rule, RuleArgs, RuleResult};
 use std::{
     collections::HashSet,
     fmt,
@@ -532,7 +532,6 @@ impl<'c> ProofChecker<'c> {
             // resolution rule will be called. Until that is decided and added to the specification,
             // we define a new specialized rule that calls it
             "strict_resolution" => resolution::strict_resolution,
-            "rare_rewrite" => check_rare,
             _ => return None,
         })
     }

--- a/carcara/src/checker/rules/mod.rs
+++ b/carcara/src/checker/rules/mod.rs
@@ -164,7 +164,6 @@ pub(super) mod extras;
 pub(super) mod linear_arithmetic;
 pub(super) mod pb_blasting;
 pub(super) mod quantifier;
-pub(super) mod rare;
 pub(super) mod reflexivity;
 pub(super) mod resolution;
 pub(super) mod simplification;

--- a/carcara/src/checker/rules/rare.rs
+++ b/carcara/src/checker/rules/rare.rs
@@ -1,5 +1,0 @@
-use super::{RuleArgs, RuleResult};
-
-pub fn check_rare(RuleArgs { .. }: RuleArgs) -> RuleResult {
-    unreachable!()
-}


### PR DESCRIPTION
The current state is not satisfactory: an Alethe proof containing a `rare_rewrite` step given to Carcara will lead to a crash. While the checking of `rare_rewrite` is not incorporated the behavior of the system should be the same as before (flag this as an unknown rule and ignore it if `-i` was given).