### PR TITLE
Fix poly subs 

### DIFF
--- a/carcara/src/ast/substitution.rs
+++ b/carcara/src/ast/substitution.rs
@@ -75,11 +75,7 @@ impl Substitution {
                 return Err(SubstitutionError::NotAVariable(k.clone()));
             }
             if pool.sort(k) != pool.sort(v)
-                && !pool
-                    .sort(k)
-                    .as_sort()
-                    .map(|x| x.is_polymorphic())
-                    .unwrap_or(false)
+                && !pool.sort(k).as_sort().is_some_and(Sort::is_polymorphic)
             {
                 return Err(SubstitutionError::DifferentSorts(k.clone(), v.clone()));
             }


### PR DESCRIPTION
In substitution, we would like to substitute poly types with any concrete term. 
Please be aware that it is enabled to perform substitution in a not-necessarily well-typed phase.