### PR TITLE
adding support for pow2/log2 operators

### DIFF
--- a/carcara/src/ast/evaluate.rs
+++ b/carcara/src/ast/evaluate.rs
@@ -286,6 +286,31 @@ fn eval_op(op: Operator, args: &[Rc<Term>]) -> Option<Value> {
             Value::Real(r) => Value::Real(r.clone().abs()),
             _ => return None,
         },
+        Operator::Pow2 => {
+            let v = args[0].as_int()?;
+            if v < 0 {
+                return Some(Value::Integer(Integer::from(0)));
+            }
+            if v == 0 {
+                return Some(Value::Integer(Integer::from(1)));
+            }
+            let v = v.to_usize()?;
+            let two = Value::Integer(Integer::from(2));
+            let twos = vec![two; v];
+            arith_op!(*, twos)
+        }
+        Operator::Log2 => {
+            let v = args[0].as_int()?;
+            if v <= 0 {
+                Value::Integer(Integer::from(0))
+            } else {
+                Value::Integer(Integer::from(v.significant_bits() - 1))
+            }
+        }
+        Operator::IsPow2 => {
+            let v = args[0].as_int()?;
+            Value::Bool(v.is_power_of_two())
+        }
         Operator::LessThan => comparison_op!(<, args),
         Operator::GreaterThan => comparison_op!(>, args),
         Operator::LessEq => comparison_op!(<=, args),

--- a/carcara/src/ast/evaluate.rs
+++ b/carcara/src/ast/evaluate.rs
@@ -291,13 +291,8 @@ fn eval_op(op: Operator, args: &[Rc<Term>]) -> Option<Value> {
             if v < 0 {
                 return Some(Value::Integer(Integer::from(0)));
             }
-            if v == 0 {
-                return Some(Value::Integer(Integer::from(1)));
-            }
             let v = v.to_usize()?;
-            let two = Value::Integer(Integer::from(2));
-            let twos = vec![two; v];
-            arith_op!(*, twos)
+            Value::Integer(Integer::from(1) << v)
         }
         Operator::Log2 => {
             let v = args[0].as_int()?;

--- a/carcara/src/ast/pool/mod.rs
+++ b/carcara/src/ast/pool/mod.rs
@@ -255,6 +255,8 @@ impl PrimitivePool {
                 | Operator::ReKleeneCross
                 | Operator::ReOption
                 | Operator::ReRange => Sort::RegLan,
+                Operator::Pow2 | Operator::Log2 => Sort::Int,
+                Operator::IsPow2 => Sort::Bool,
                 Operator::RareList => Sort::RareList,
             },
             Term::App(f, args) => {

--- a/carcara/src/ast/term.rs
+++ b/carcara/src/ast/term.rs
@@ -372,6 +372,12 @@ pub enum Operator {
     BvConst,
     BvSize,
 
+    // power of 2 to x, and whether x is a power of 2
+    Pow2,
+    IsPow2,
+    // logarithm in base 2 of x
+    Log2,
+
     // Misc.
     /// The `rare-list` operator, used to represent RARE lists.
     RareList,
@@ -489,6 +495,9 @@ impl Operator {
             | Operator::BvBbTerm
             | Operator::BvConst
             | Operator::BvSize
+            | Operator::Pow2
+            | Operator::IsPow2
+            | Operator::Log2
             | Operator::RareList => None,
 
             // Clausal
@@ -623,6 +632,10 @@ impl_str_conversion_traits!(Operator {
     BvBbTerm: "@bbterm",
     BvConst: "@bv",
     BvSize: "@bvsize",
+
+    Pow2: "int.pow2",
+    IsPow2: "int.ispow2",
+    Log2: "int.log2",
 
     RareList: "rare-list",
 

--- a/carcara/src/parser/mod.rs
+++ b/carcara/src/parser/mod.rs
@@ -515,6 +515,10 @@ impl<'a, R: BufRead> Parser<'a, R> {
                 }
                 SortError::assert_all_eq(&sorts)?;
             }
+            Operator::Pow2 | Operator::Log2 | Operator::IsPow2 => {
+                assert_num_args(&args, 1)?;
+                SortError::assert_eq(&Sort::Int, sorts[0])?;
+            }
             Operator::RareList => SortError::assert_all_eq(&sorts)?,
         }
         Ok(self.pool.add(Term::Op(op, args)))


### PR DESCRIPTION
These operators are used in rare rewrites for cvc5. We may want to change the identifiers for them later.