### PR TITLE
Generalize macro language to allow int and real numbers

### DIFF
--- a/carcara/src/ast/macros.rs
+++ b/carcara/src/ast/macros.rs
@@ -224,7 +224,7 @@ macro_rules! match_term {
     (@GET_VARIANT strinre)    => { $crate::ast::Operator::StrInRe };
     (@GET_VARIANT reinter)    => { $crate::ast::Operator::ReIntersection };
 
-    // In the last case it can match a literal integer
+    // In the last case it can match a literal of an integer or rational
     ($lit:literal = $var:expr) => {
         if let Some(i) = $var.as_number() {
             if i == $lit {


### PR DESCRIPTION
As a consequence, the macro language is agnostic to types for numbers, i.e., 1 can match with 1.0 and vice-versa. This is not problematic however because if there are typing issues these will be caught during parsing.