### PR TITLE
Add a new rule `eq_mp` and its elaboration

### DIFF
--- a/carcara/src/checker/rules/extras.rs
+++ b/carcara/src/checker/rules/extras.rs
@@ -76,6 +76,18 @@ pub fn eq_symmetric(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     assert_eq(u_1, u_2)
 }
 
+pub fn eq_mp(RuleArgs { conclusion, premises, .. }: RuleArgs) -> RuleResult {
+    assert_num_premises(premises, 2)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let phi_1 = get_premise_term(&premises[0])?;
+    let equivalence = get_premise_term(&premises[1])?;
+    let (left, right) = match_term_err!((= phi_1 phi_2) = equivalence)?;
+
+    assert_eq(left, phi_1)?;
+    assert_eq(right, &conclusion[0])
+}
+
 pub fn weakening(RuleArgs { conclusion, premises, .. }: RuleArgs) -> RuleResult {
     assert_num_premises(premises, 1)?;
     let premise = premises[0].clause;

--- a/carcara/src/checker/shared.rs
+++ b/carcara/src/checker/shared.rs
@@ -311,6 +311,7 @@ pub fn get_rule(
         "symm" => extras::symm,
         "not_symm" => extras::not_symm,
         "eq_symmetric" => extras::eq_symmetric,
+        "eq_mp" => extras::eq_mp,
         "weakening" => extras::weakening,
         "bind_let" => extras::bind_let,
         "la_mult_pos" => extras::la_mult_pos,

--- a/carcara/src/elaborator/local/eq_mp.rs
+++ b/carcara/src/elaborator/local/eq_mp.rs
@@ -1,0 +1,59 @@
+use crate::{
+    ast::*,
+    elaborator::{error::ElaborationError, IdHelper},
+};
+
+/// Elaborates an `eq_mp` step into a `resolution` step taking the
+/// original premises and a new `equiv_pos2` step.
+///
+/// That is, a step of the form
+/// ```text
+/// (step t3 (cl F2) :rule eq_mp :premises (t1 t2))
+/// ```
+/// where `t1` concludes `F1` and `t2` concludes `(= F1 F2)`, becomes
+/// ```text
+/// (step t3.t1 (cl (not (= F1 F2)) (not F1) F2) :rule equiv_pos2)
+/// (step t3 (cl F2) :rule resolution :premises (t3.t1 t2 t1) :args ((= F1 F2) false F1 false))
+/// ```
+pub fn eq_mp(
+    pool: &mut PrimitivePool,
+    _: &mut ContextStack,
+    step: &StepNode,
+) -> Result<Rc<ProofNode>, ElaborationError> {
+    assert_eq!(step.clause.len(), 1);
+    assert_eq!(step.premises.len(), 2);
+    let (phi_1_step, equiv_step) = (&step.premises[0], &step.premises[1]);
+    assert_eq!(equiv_step.clause().len(), 1);
+
+    let equivalence = equiv_step.clause()[0].clone();
+    let (phi_1, phi_2) = match_term_err!((= phi_1 phi_2) = &equivalence)?;
+    let (phi_1, phi_2) = (phi_1.clone(), phi_2.clone());
+
+    // If `phi_2` is exactly the negation of `phi_1`, the last two literals introduced by
+    // `equiv_pos2` are the same, and the resolution below would derive the empty clause instead of
+    // the step's conclusion. That can only happen if the premises are contradictory, in which case
+    // we simply leave the step as it is.
+    if match_term!((not phi) = &phi_2) == Some(&phi_1) {
+        return Ok(Rc::new(ProofNode::Step(step.clone())));
+    }
+
+    let equiv_pos2_step = Rc::new(ProofNode::Step(StepNode {
+        id: IdHelper::new(&step.id).next_id(),
+        depth: step.depth,
+        clause: vec![
+            build_term!(pool, (not {equivalence.clone()})),
+            build_term!(pool, (not {phi_1.clone()})),
+            phi_2,
+        ],
+        rule: "equiv_pos2".to_owned(),
+        ..Default::default()
+    }));
+
+    let f = pool.bool_false();
+    Ok(Rc::new(ProofNode::Step(StepNode {
+        rule: "resolution".to_owned(),
+        premises: vec![equiv_pos2_step, equiv_step.clone(), phi_1_step.clone()],
+        args: vec![equivalence, f.clone(), phi_1, f],
+        ..step.clone()
+    })))
+}

--- a/carcara/src/elaborator/local/eq_mp.rs
+++ b/carcara/src/elaborator/local/eq_mp.rs
@@ -15,6 +15,10 @@ use crate::{
 /// (step t3.t1 (cl (not (= F1 F2)) (not F1) F2) :rule equiv_pos2)
 /// (step t3 (cl F2) :rule resolution :premises (t3.t1 t2 t1) :args ((= F1 F2) false F1 false))
 /// ```
+///
+/// If `F2` is the negation of `F1`, the last two literals of the `equiv_pos2` step are the same, so
+/// the resolution would conclude the empty clause. It can conclude `F2` however if the resolution is
+/// just with `t2`.
 pub fn eq_mp(
     pool: &mut PrimitivePool,
     _: &mut ContextStack,
@@ -28,17 +32,18 @@ pub fn eq_mp(
     let equivalence = equiv_step.clause()[0].clone();
     let (phi_1, phi_2) = match_term_err!((= phi_1 phi_2) = &equivalence)?;
     let (phi_1, phi_2) = (phi_1.clone(), phi_2.clone());
+    let special_case = match_term!((not phi) = &phi_2) == Some(&phi_1);
 
-    // If `phi_2` is exactly the negation of `phi_1`, the last two literals introduced by
-    // `equiv_pos2` are the same, and the resolution below would derive the empty clause instead of
-    // the step's conclusion. That can only happen if the premises are contradictory, in which case
-    // we simply leave the step as it is.
-    if match_term!((not phi) = &phi_2) == Some(&phi_1) {
-        return Ok(Rc::new(ProofNode::Step(step.clone())));
+    let mut ids = IdHelper::new(&step.id);
+    // The resolution that will be introduced in the special case relies on
+    // duplicate removal. In the `uncrowd` pass, if that is active, a
+    // `contraction` step would be added. To avoid clashing of ids, we make sure
+    // that equiv_pos2 is one step deeper.
+    if special_case {
+        ids.push();
     }
-
     let equiv_pos2_step = Rc::new(ProofNode::Step(StepNode {
-        id: IdHelper::new(&step.id).next_id(),
+        id: ids.next_id(),
         depth: step.depth,
         clause: vec![
             build_term!(pool, (not {equivalence.clone()})),
@@ -48,12 +53,18 @@ pub fn eq_mp(
         rule: "equiv_pos2".to_owned(),
         ..Default::default()
     }));
-
     let f = pool.bool_false();
+    let mut premises = vec![equiv_pos2_step, equiv_step.clone()];
+    let mut args = vec![equivalence, f.clone()];
+    if !special_case {
+        premises.push(phi_1_step.clone());
+        args.extend([phi_1, f]);
+    }
+
     Ok(Rc::new(ProofNode::Step(StepNode {
         rule: "resolution".to_owned(),
-        premises: vec![equiv_pos2_step, equiv_step.clone(), phi_1_step.clone()],
-        args: vec![equivalence, f.clone(), phi_1, f],
+        premises,
+        args,
         ..step.clone()
     })))
 }

--- a/carcara/src/elaborator/local/mod.rs
+++ b/carcara/src/elaborator/local/mod.rs
@@ -1,4 +1,5 @@
 pub mod congruence;
+pub mod eq_mp;
 pub mod farkas;
 pub mod resolution;
 pub mod transitivity;

--- a/carcara/src/elaborator/mod.rs
+++ b/carcara/src/elaborator/mod.rs
@@ -178,6 +178,7 @@ impl<'e> Elaborator<'e> {
                 "cong" => local::congruence::cong,
                 "eq_congruent" => local::congruence::eq_congruent,
                 "bounded_farkas" => local::farkas::bounded_farkas,
+                "eq_mp" => local::eq_mp::eq_mp,
                 _ => return None,
             })
         }

--- a/carcara/tests/rules/extras.rs
+++ b/carcara/tests/rules/extras.rs
@@ -104,6 +104,66 @@ fn eq_symmetric() {
 }
 
 #[test]
+fn eq_mp() {
+    test_cases! {
+        definitions = "
+            (declare-fun p () Bool)
+            (declare-fun q () Bool)
+            (declare-fun r () Bool)
+            (declare-fun a () Int)
+            (declare-fun b () Int)
+        ",
+        "Simple working examples" {
+            "(assume h1 p)
+            (assume h2 (= p q))
+            (step t3 (cl q) :rule eq_mp :premises (h1 h2))": true,
+
+            "(assume h1 (not p))
+            (assume h2 (= (not p) (or q r)))
+            (step t3 (cl (or q r)) :rule eq_mp :premises (h1 h2))": true,
+
+            "(assume h1 (< a b))
+            (assume h2 (= (< a b) (not (>= a b))))
+            (step t3 (cl (not (>= a b))) :rule eq_mp :premises (h1 h2))": true,
+
+            "(assume h1 p)
+            (assume h2 (= p p))
+            (step t3 (cl p) :rule eq_mp :premises (h1 h2))": true,
+        }
+        "Premises in the wrong order" {
+            "(assume h1 p)
+            (assume h2 (= p q))
+            (step t3 (cl q) :rule eq_mp :premises (h2 h1))": false,
+        }
+        "Equivalence is flipped" {
+            "(assume h1 p)
+            (assume h2 (= q p))
+            (step t3 (cl q) :rule eq_mp :premises (h1 h2))": false,
+        }
+        "Failing examples" {
+            "(assume h1 p)
+            (assume h2 (= p q))
+            (step t3 (cl r) :rule eq_mp :premises (h1 h2))": false,
+
+            "(assume h1 p)
+            (assume h2 (= p q))
+            (step t3 (cl q r) :rule eq_mp :premises (h1 h2))": false,
+
+            "(assume h1 p)
+            (assume h2 (=> p q))
+            (step t3 (cl q) :rule eq_mp :premises (h1 h2))": false,
+
+            "(assume h1 (= p q))
+            (step t3 (cl q) :rule eq_mp :premises (h1))": false,
+
+            "(step t1 (cl p r) :rule hole)
+            (assume h2 (= p q))
+            (step t3 (cl q) :rule eq_mp :premises (t1 h2))": false,
+        }
+    }
+}
+
+#[test]
 fn weakening() {
     test_cases! {
         definitions = "

--- a/docs/src/elaboration/local.md
+++ b/docs/src/elaboration/local.md
@@ -6,6 +6,7 @@ small local way. These are grouped in the `local` elaboration pass. The rules af
 - `eq_congruent`
 - `cong`
 - `resolution`
+- `eq_mp`
 
 ## Transitivity rules
 The `eq_transitive` and `trans` rules may sometimes contain the transitivity chain in an incorrect
@@ -82,3 +83,22 @@ elaborated step will be:
 (step t4 (cl r) :rule resolution :premises (t1 t2 t3) :args (p true q false))
 ```
 
+## `eq_mp` rule
+The `eq_mp` rule is not part of the Alethe specification. It is an extra rule, equivalent to
+CPC's `EQ_RESOLVE`, that derives `F2` from `F1` and `(= F1 F2)`:
+```
+(assume h1 p)
+(assume h2 (= p q))
+(step t3 (cl q) :rule eq_mp :premises (h1 h2))
+```
+During elaboration, it is replaced by a `resolution` step taking the original
+premises and a new `equiv_pos2` step:
+```
+(assume h1 p)
+(assume h2 (= p q))
+(step t3.t1 (cl (not (= p q)) (not p) q) :rule equiv_pos2)
+(step t3 (cl q) :rule resolution :premises (t3.t1 h2 h1) :args ((= p q) false p false))
+```
+A guard is added for the case where `F2` is the negation of `F1`, that is, when the premises are
+contradictory. In that case the last two literals of the `equiv_pos2` step would be the same, and
+the resolution would derive the empty clause instead of `(cl F2)`, so the step is left unchanged.

--- a/docs/src/elaboration/local.md
+++ b/docs/src/elaboration/local.md
@@ -99,6 +99,16 @@ premises and a new `equiv_pos2` step:
 (step t3.t1 (cl (not (= p q)) (not p) q) :rule equiv_pos2)
 (step t3 (cl q) :rule resolution :premises (t3.t1 h2 h1) :args ((= p q) false p false))
 ```
-A guard is added for the case where `F2` is the negation of `F1`, that is, when the premises are
-contradictory. In that case the last two literals of the `equiv_pos2` step would be the same, and
-the resolution would derive the empty clause instead of `(cl F2)`, so the step is left unchanged.
+In the odd case where `q` is exactly `(not p)` this pattern would break the
+resolution, so instead the elaboration is done with a resolution step that
+considers just the equivalence premise and relies on implicit duplicate
+elimination (which can be further eliminated by other elaboration passes if they
+are active). The `equiv_pos2` step is nested one level deeper here, so that its
+id does not clash with the ones used by the `uncrowd` pass when it adds the
+`contraction` step that removes the duplicate:
+```
+(assume h1 p)
+(assume h2 (= p (not p)))
+(step t3.t1.t1 (cl (not (= p (not p))) (not p) (not p)) :rule equiv_pos2)
+(step t3 (cl (not p)) :rule resolution :premises (t3.t1.t1 h2) :args ((= p (not p)) false))
+```


### PR DESCRIPTION
This commit adds a new extra rule, `eq_mp`, that represents a common pattern in Alethe proofs where a formula is used to derive another that is equivalent to it from a proof of this equivalence. An elaboration to the regular way to do this with current rules is also added. 

Specifically, the rule derives `F2` from `F1` and `(= F1 F2)` and the local elaboration pass replaces it with a resolution taking the original premises and a new `equiv_pos2` step. 

A guard is added for when `F2` is the negation of `F1`, in which case the two literals introduced by `equiv_pos2` collapse into one and the resolution would derive the empty clause, so the step is left as is.

Claude was used to write the code from my description of the rule and the elaboration, and I inspected the result, manually making the elaboration code a bit more succinct. 

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
