### PR TITLE
Check that terms with the same name in match_term! are equal

### DIFF
--- a/carcara-macros/src/lib.rs
+++ b/carcara-macros/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate proc_macro;
 
+use std::collections::HashMap;
+
 use proc_macro::TokenStream;
 use proc_macro2::{Delimiter, Ident, Spacing, TokenStream as TokenStream2, TokenTree};
 use quote::{format_ident, quote};
@@ -23,6 +25,15 @@ impl Parse for Input {
     }
 }
 
+// A counter for generating unique idents, and the names bound so far,
+// used to detect repeated names.
+struct ParseCtx {
+    ctr: usize,
+    // Maps a name written by the user to the generated ident bound by its
+    // first occurrence in the pattern.
+    bound: HashMap<String, Ident>,
+}
+
 // Internal representation of the s-expression pattern.
 //
 // Every free variable and binder binding list gets a unique generated Ident so
@@ -39,7 +50,14 @@ enum Pat {
     // Real/rational literal
     LiteralReal(f64),
     // Each occurrence gets a unique generated ident to avoid shadowing.
-    FreeVar(Ident),
+    FreeVar {
+        id: Ident,
+        // `Some(first)` when this name already appeared earlier in the pattern.
+        // Such an occurrence doesn't capture anything: instead, the generated
+        // code checks that this term is equal to the one bound by `first`, and
+        // the match fails if it isn't.
+        same_as: Option<Ident>,
+    },
     // Carries a generated name that will hold the captured &[Rc<Term>] slice.
     Variadic(Ident),
     Op {
@@ -64,9 +82,14 @@ enum Pat {
 impl Pat {
     /// Collects all free variables in depth-first, left-to-right order.
     /// This order determines the flat tuple returned by the macro.
+    ///
+    /// Repeated occurrences of a name are not included: they are turned into
+    /// equality checks instead of captures, so a name always contributes
+    /// exactly one element to the tuple, no matter how many times it appears.
     fn free_vars(&self) -> Vec<Ident> {
         match self {
-            Pat::FreeVar(id) => vec![id.clone()],
+            Pat::FreeVar { same_as: Some(_), .. } => Vec::new(),
+            Pat::FreeVar { id, same_as: None } => vec![id.clone()],
             // Variadic contributes the slice ident as one element of the tuple.
             Pat::Variadic(id) => vec![id.clone()],
             Pat::Op { args, .. } => args.iter().flat_map(|p| p.free_vars()).collect(),
@@ -111,35 +134,53 @@ fn is_three_dots(tokens: &[TokenTree], i: usize) -> bool {
 
 // Parses a slice of tokens as a list of pattern arguments, handling '...'
 // variadics. Shared between regular Op and ParamOp argument parsing.
-fn parse_args(tokens: &[TokenTree], ctr: &mut usize) -> Vec<Pat> {
+fn parse_args(tokens: &[TokenTree], ctx: &mut ParseCtx) -> Vec<Pat> {
     let mut args = Vec::new();
     let mut i = 0;
     while i < tokens.len() {
         if is_three_dots(tokens, i) {
             // Generate a unique ident for this variadic capture.
-            *ctr += 1;
-            args.push(Pat::Variadic(format_ident!("__mt_variadic_{}", ctr)));
+            ctx.ctr += 1;
+            args.push(Pat::Variadic(format_ident!("__mt_variadic_{}", ctx.ctr)));
             i += 3;
             continue;
         }
-        args.push(parse_pat(tokens[i].clone(), ctr));
+        args.push(parse_pat(tokens[i].clone(), ctx));
         i += 1;
     }
     args
 }
 
 // Recursively parses a TokenTree into a Pat.
-// 'ctr' is used to generate unique idents for all captures.
-fn parse_pat(tt: TokenTree, ctr: &mut usize) -> Pat {
+// 'ctx' provides the counter used to generate unique idents for all captures,
+// and tracks which names have already been bound.
+fn parse_pat(tt: TokenTree, ctx: &mut ParseCtx) -> Pat {
     match tt {
         TokenTree::Ident(id) => match id.to_string().as_str() {
             "true" => Pat::True,
             "false" => Pat::False,
             // Every free variable gets a unique generated ident. This prevents
             // repeated names from shadowing each other in the generated let bindings.
-            _ => {
-                *ctr += 1;
-                Pat::FreeVar(format_ident!("__mt_var_{}", ctr))
+            name => {
+                ctx.ctr += 1;
+                let new_id = format_ident!("__mt_var_{}", ctx.ctr);
+
+                // '_' is a wildcard: each occurrence matches anything, and it
+                // never has to be equal to any other occurrence.
+                let same_as = if name == "_" {
+                    None
+                } else {
+                    // If this name was already bound, this occurrence becomes an
+                    // equality check against the term captured by the first one.
+                    match ctx.bound.get(name) {
+                        Some(first) => Some(first.clone()),
+                        None => {
+                            ctx.bound.insert(name.to_owned(), new_id.clone());
+                            None
+                        }
+                    }
+                };
+                Pat::FreeVar { id: new_id, same_as }
             }
         },
 
@@ -180,12 +221,12 @@ fn parse_pat(tt: TokenTree, ctr: &mut usize) -> Pat {
                     let inner_tt = tokens[4].clone();
                     // Generate a unique ident for this binder's bindings so that
                     // multiple binders in one pattern don't shadow each other.
-                    *ctr += 1;
-                    let bindings_id = format_ident!("__mt_bindings_{}", ctr);
+                    ctx.ctr += 1;
+                    let bindings_id = format_ident!("__mt_bindings_{}", ctx.ctr);
                     return Pat::Binder {
                         binder: name,
                         bindings_id,
-                        inner: Box::new(parse_pat(inner_tt, ctr)),
+                        inner: Box::new(parse_pat(inner_tt, ctx)),
                     };
                 }
             }
@@ -197,8 +238,8 @@ fn parse_pat(tt: TokenTree, ctr: &mut usize) -> Pat {
                     let inner_tokens: Vec<_> = inner.stream().into_iter().collect();
                     if matches!(&inner_tokens[0], TokenTree::Ident(id) if *id == "_") {
                         let (op, op_len) = read_op(&inner_tokens[1..]);
-                        let op_args = parse_args(&inner_tokens[1 + op_len..], ctr);
-                        let args = parse_args(&tokens[1..], ctr);
+                        let op_args = parse_args(&inner_tokens[1 + op_len..], ctx);
+                        let args = parse_args(&tokens[1..], ctx);
                         return Pat::ParamOp { op, op_args, args };
                     }
                 }
@@ -206,7 +247,7 @@ fn parse_pat(tt: TokenTree, ctr: &mut usize) -> Pat {
 
             // Regular Op pattern - read operator, then parse args.
             let (op, op_len) = read_op(&tokens);
-            let args = parse_args(&tokens[op_len..], ctr);
+            let args = parse_args(&tokens[op_len..], ctx);
             Pat::Op { op, args }
         }
 
@@ -336,8 +377,14 @@ fn gen_match(pat: &Pat, var: &TokenStream2, inner: TokenStream2, ctr: &mut usize
         Pat::LiteralReal(f) => quote! {
             if (#var).as_fraction().is_some_and(|r| r == #f) { #inner } else { None }
         },
-        Pat::FreeVar(id) => quote! {
+        // First occurrence of a name -> capture the term.
+        Pat::FreeVar { id, same_as: None } => quote! {
             { let #id = #var; #inner }
+        },
+        // Repeated occurrence: the term must be equal to the one captured by the
+        // first occurrence, otherwise the whole match fails.
+        Pat::FreeVar { same_as: Some(first), .. } => quote! {
+            if (#var) == (#first) { #inner } else { None }
         },
         // Variadic as a standalone pattern: bind the value directly.
         Pat::Variadic(id) => quote! {
@@ -507,8 +554,8 @@ pub fn match_term(input: TokenStream) -> TokenStream {
     // Single counter shared between parse_pat (for variable/variadic/binder idents)
     // and gen_match (for temporary arg idents). gen_match starts at 1000 to avoid
     // collisions with the idents generated by parse_pat.
-    let mut parse_ctr = 0usize;
-    let pat = parse_pat(pattern, &mut parse_ctr);
+    let mut ctx = ParseCtx { ctr: 0, bound: HashMap::new() };
+    let pat = parse_pat(pattern, &mut ctx);
     let free_vars = pat.free_vars();
 
     // Innermost code: return a flat tuple of all captured variables.

--- a/carcara/src/ast/macros.rs
+++ b/carcara/src/ast/macros.rs
@@ -194,6 +194,54 @@ mod tests {
     }
 
     #[test]
+    fn test_match_term_repeated_names() {
+        let mut p = PrimitivePool::new();
+        let (true_, false_) = (p.bool_true(), p.bool_false());
+        let not_true = p.add(Term::Op(Operator::Not, vec![true_]));
+        let not_false = p.add(Term::Op(Operator::Not, vec![false_]));
+
+        // A name used more than once only matches if all the terms bound to it are equal, and it
+        // contributes a single element to the resulting tuple
+        let term = parse_term(&mut p, "(= (not true) (not true))");
+        let t: &Rc<Term> = match_term!((= x x) = &term).unwrap();
+        assert_eq!(t, &not_true);
+
+        let term = parse_term(&mut p, "(= (not true) (not false))");
+        assert!(match_term!((= x x) = &term).is_none());
+
+        // Distinct names still match distinct terms
+        let (a, b) = match_term!((= x y) = &term).unwrap();
+        assert_eq!(a, &not_true);
+        assert_eq!(b, &not_false);
+
+        // Repeated names in nested positions, mixed with distinct ones
+        let term = parse_term(&mut p, "(= (= 1 2) (and (<= 1 2) (<= 2 1)))");
+        let (t, u) = match_term!((= (= t u) (and (<= t u) (<= u t))) = &term).unwrap();
+        assert_eq!(1, t.as_integer().unwrap());
+        assert_eq!(2, u.as_integer().unwrap());
+
+        let term = parse_term(&mut p, "(= (= 1 2) (and (<= 1 2) (<= 2 5)))");
+        assert!(match_term!((= (= t u) (and (<= t u) (<= u t))) = &term).is_none());
+
+        // '_' is a wildcard: distinct occurrences don't have to be equal, but they are still
+        // captured
+        let term = parse_term(&mut p, "(= 1 2)");
+        let (a, b) = match_term!((= _ _) = &term).unwrap();
+        assert_eq!(1, a.as_integer().unwrap());
+        assert_eq!(2, b.as_integer().unwrap());
+
+        // Repeated names inside a binder's body
+        let term = parse_term(&mut p, "(forall ((x Int)) (= (not true) (not true)))");
+        let (bindings, t): (&BindingList, &Rc<Term>) =
+            match_term!((forall ... (= x x)) = &term).unwrap();
+        assert_eq!(1, bindings.len());
+        assert_eq!(t, &not_true);
+
+        let term = parse_term(&mut p, "(forall ((x Int)) (= (not true) (not false)))");
+        assert!(match_term!((forall ... (= x x)) = &term).is_none());
+    }
+
+    #[test]
     fn test_build_term() {
         let definitions = "
             (declare-fun a () Int)

--- a/carcara/src/checker/rules/extras.rs
+++ b/carcara/src/checker/rules/extras.rs
@@ -71,9 +71,8 @@ pub fn not_symm(RuleArgs { conclusion, premises, .. }: RuleArgs) -> RuleResult {
 
 pub fn eq_symmetric(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 1)?;
-    let (t_1, u_1, u_2, t_2) = match_term_err!((= (= t u) (= u t)) = &conclusion[0])?;
-    assert_eq(t_1, t_2)?;
-    assert_eq(u_1, u_2)
+    match_term_err!((= (= t u) (= u t)) = &conclusion[0])?;
+    Ok(())
 }
 
 pub fn eq_mp(RuleArgs { conclusion, premises, .. }: RuleArgs) -> RuleResult {

--- a/carcara/src/checker/rules/linear_arithmetic.rs
+++ b/carcara/src/checker/rules/linear_arithmetic.rs
@@ -9,13 +9,8 @@ use rug::{ops::NegAssign, Integer, Rational};
 pub fn la_rw_eq(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 1)?;
 
-    let (t_1, u_1, t_2, u_2, u_3, t_3) = match_term_err!(
-        (= (= t u) (and (<= t u) (<= u t))) = &conclusion[0]
-    )?;
-    assert_eq(t_1, t_2)?;
-    assert_eq(t_2, t_3)?;
-    assert_eq(u_1, u_2)?;
-    assert_eq(u_2, u_3)
+    match_term_err!((= (= t u) (and (<= t u) (<= u t))) = &conclusion[0])?;
+    Ok(())
 }
 
 /// Takes a disequality term and returns its negation, represented by an operator and two linear
@@ -383,22 +378,15 @@ pub fn la_generic_partial(
 pub fn la_disequality(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 1)?;
 
-    let (t1_1, t2_1, t1_2, t2_2, t2_3, t1_3) = match_term_err!(
-        (or (= t1 t2) (not (<= t1 t2)) (not (<= t2 t1))) = &conclusion[0]
-    )?;
-    assert_eq(t1_1, t1_2)?;
-    assert_eq(t1_2, t1_3)?;
-    assert_eq(t2_1, t2_2)?;
-    assert_eq(t2_2, t2_3)
+    match_term_err!((or (= t1 t2) (not (<= t1 t2)) (not (<= t2 t1))) = &conclusion[0])?;
+    Ok(())
 }
 
 pub fn la_totality(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 1)?;
 
-    let (t1_1, t2_1, t2_2, t1_2) = match_term_err!((or (<= t1 t2) (<= t2 t1)) = &conclusion[0])?;
-
-    assert_eq(t1_1, t1_2)?;
-    assert_eq(t2_1, t2_2)
+    match_term_err!((or (<= t1 t2) (<= t2 t1)) = &conclusion[0])?;
+    Ok(())
 }
 
 fn assert_less_than(a: &Rc<Term>, b: &Rc<Term>) -> RuleResult {

--- a/carcara/src/checker/rules/quantifier.rs
+++ b/carcara/src/checker/rules/quantifier.rs
@@ -384,19 +384,16 @@ pub fn miniscope_split(RuleArgs { conclusion, pool, .. }: RuleArgs) -> RuleResul
 
 pub fn miniscope_ite(RuleArgs { conclusion, pool, .. }: RuleArgs) -> RuleResult {
     assert_clause_len(conclusion, 1)?;
-    let (bindings_1, phi1_l, phi2_l, phi3_l, phi1_r, bindings_2, phi2_r, bindings_3, phi3_r) = match_term_err!(
+    let (bindings_1, phi1, _, _, bindings_2, bindings_3) = match_term_err!(
         (= (forall ... (ite phi1 phi2 phi3)) (ite phi1 (forall ... phi2) (forall ... phi3)))
         = &conclusion[0]
     )?;
-    assert_eq(phi1_l, phi1_r)?;
-    assert_eq(phi2_l, phi2_r)?;
-    assert_eq(phi3_l, phi3_r)?;
     assert_eq(bindings_1, bindings_2)?;
     assert_eq(bindings_1, bindings_3)?;
-    let free_vars = pool.free_vars(phi1_l);
+    let free_vars = pool.free_vars(phi1);
     for v in bindings_1 {
         if free_vars.contains(&pool.add(v.clone().into())) {
-            return Err(QuantifierError::MiniscopeFreeVar(v.0.clone(), phi1_l.clone()).into());
+            return Err(QuantifierError::MiniscopeFreeVar(v.0.clone(), phi1.clone()).into());
         }
     }
     Ok(())

--- a/carcara/src/checker/rules/simplification.rs
+++ b/carcara/src/checker/rules/simplification.rs
@@ -95,7 +95,7 @@ pub fn ite_simplify(args: RuleArgs) -> RuleResult {
             (ite false t_1 t_2): (_, t_2) => t_2.clone(),
 
             // ite phi t t => t
-            (ite phi t t): (_, t_1, t_2) if t_1 == t_2 => t_1.clone(),
+            (ite phi t t): (_, t) => t.clone(),
 
             // ite psi true false => psi
             (ite psi true false): psi => psi.clone(),
@@ -109,13 +109,13 @@ pub fn ite_simplify(args: RuleArgs) -> RuleResult {
             },
 
             // ite phi (ite phi t_1 t_2) t_3 => ite phi t_1 t_3
-            (ite phi (ite phi t_1 t_2) t_3): (phi_1, phi_2, t_1, _, t_3) if phi_1 == phi_2 => {
-                build_term!(pool, (ite {phi_1.clone()} {t_1.clone()} {t_3.clone()}))
+            (ite phi (ite phi t_1 t_2) t_3): (phi, t_1, _, t_3) => {
+                build_term!(pool, (ite {phi.clone()} {t_1.clone()} {t_3.clone()}))
             },
 
             // ite phi t_1 (ite phi t_2 t_3) => ite phi t_1 t_3
-            (ite phi t_1 (ite phi t_2 t_3)): (phi_1, t_1, phi_2, _, t_3) if phi_1 == phi_2 => {
-                build_term!(pool, (ite {phi_1.clone()} {t_1.clone()} {t_3.clone()}))
+            (ite phi t_1 (ite phi t_2 t_3)): (phi, t_1, _, t_3) => {
+                build_term!(pool, (ite {phi.clone()} {t_1.clone()} {t_3.clone()}))
             },
 
             // ite psi true phi => psi v phi
@@ -145,17 +145,17 @@ pub fn eq_simplify(args: RuleArgs) -> RuleResult {
     generic_simplify_rule(args.conclusion, args.pool, |term, pool| {
         simplify!(term {
             // t = t => true
-            (= t t): (t1, t2) if t1 == t2 => pool.bool_true(),
+            (= t t): _ => pool.bool_true(),
 
             // t_1 = t_2 => false, if t_1 and t_2 are different numerical constants
-            (= t t): (t1, t2) if {
-                let t1 = t1.as_signed_number();
-                let t2 = t2.as_signed_number();
-                t1.is_some() && t2.is_some() && t1 != t2
+            (= t_1 t_2): (t_1, t_2) if {
+                let t_1 = t_1.as_signed_number();
+                let t_2 = t_2.as_signed_number();
+                t_1.is_some() && t_2.is_some() && t_1 != t_2
             } => pool.bool_false(),
 
             // ¬(t = t) => false, if t is a numerical constant
-            (not (= t t)): (t1, t2) if t1 == t2 && t1.is_signed_number() => pool.bool_false(),
+            (not (= t t)): t if t.is_signed_number() => pool.bool_false(),
         })
     })
 }
@@ -306,7 +306,7 @@ pub fn implies_simplify(args: RuleArgs) -> RuleResult {
             (=> phi false): phi => build_term!(pool, (not {phi.clone()})),
 
             // phi -> phi => true
-            (=> phi phi): (phi_1, phi_2) if phi_1 == phi_2 => pool.bool_true(),
+            (=> phi phi): _ => pool.bool_true(),
 
             // ¬phi -> phi => phi
             // phi -> ¬phi => ¬phi
@@ -315,7 +315,7 @@ pub fn implies_simplify(args: RuleArgs) -> RuleResult {
             } => phi_2.clone(),
 
             // (phi_1 -> phi_2) -> phi_2 => phi_1 v phi_2
-            (=> (=> phi_1 phi_2) phi_3): (phi_1, phi_2, phi_3) if phi_2 == phi_3 => {
+            (=> (=> phi_1 phi_2) phi_2): (phi_1, phi_2) => {
                 build_term!(pool, (or {phi_1.clone()} {phi_2.clone()}))
             },
         })

--- a/carcara/src/checker/rules/strings.rs
+++ b/carcara/src/checker/rules/strings.rs
@@ -1177,13 +1177,15 @@ pub fn string_length_pos(RuleArgs { args, conclusion, polyeq_time, .. }: RuleArg
     assert_clause_len(conclusion, 1)?;
 
     let t = &args[0];
+    // Note that the three occurrences of 't' are matched independently, since they
+    // don't have to be identical to each other.
     let (t_1, t_2, t_3) = match_term_err!(
         (or
             (and
-                (= (strlen t) 0)
-                (= t "")
+                (= (strlen t_1) 0)
+                (= t_2 "")
             )
-            (> (strlen t) 0)
+            (> (strlen t_3) 0)
         ) = &conclusion[0]
     )?;
 


### PR DESCRIPTION
Implements the second half of #118. The first half (flattening the macro so patterns of arbitrary depth work) was done in #122