### PR TITLE
Add verification procedures for RCP calculus

### DIFF
--- a/carcara-macros/src/lib.rs
+++ b/carcara-macros/src/lib.rs
@@ -345,6 +345,8 @@ fn op_to_variant(op: &str) -> TokenStream2 {
         "strlen" => quote! { crate::ast::Operator::StrLen },
         "strinre" => quote! { crate::ast::Operator::StrInRe },
         "reinter" => quote! { crate::ast::Operator::ReIntersection },
+        "replacere" => quote! { crate::ast::Operator::ReplaceRe },
+        "replacereall" => quote! { crate::ast::Operator::ReplaceReAll },
 
         // Arrays
         "select" => quote! { crate::ast::Operator::Select },

--- a/carcara-macros/src/lib.rs
+++ b/carcara-macros/src/lib.rs
@@ -347,6 +347,7 @@ fn op_to_variant(op: &str) -> TokenStream2 {
         "reinter" => quote! { crate::ast::Operator::ReIntersection },
         "replacere" => quote! { crate::ast::Operator::ReplaceRe },
         "replacereall" => quote! { crate::ast::Operator::ReplaceReAll },
+        "indexofre" => quote! { crate::ast::Operator::IndexOfRe },
 
         // Arrays
         "select" => quote! { crate::ast::Operator::Select },

--- a/src/ast/term.rs
+++ b/src/ast/term.rs
@@ -1196,7 +1196,7 @@ impl Term {
         }
     }
 
-    /// Tries to extract a `String` from a term. Returns `Some` if the term is a string constant.
+    /// Tries to extract a `String` from a term. Returns `Some` if the term is a String constant.
     pub fn as_string(&self) -> Option<String> {
         match self {
             Term::Const(Constant::String(s)) => Some(s.to_owned()),
@@ -1276,6 +1276,14 @@ impl Term {
     pub fn as_let(&self) -> Option<(&BindingList<Rc<Term>>, &Rc<Term>)> {
         match self {
             Term::Let(b, t) => Some((b, t)),
+            _ => None,
+        }
+    }
+
+    /// Tries to unwrap an [`Automaton`] from a term. Returns `None` if the term is not a `RegLan` term.
+    pub fn as_automaton(&self) -> Option<Automaton> {
+        match self {
+            Term::Const(Constant::RegLan(_, a)) => Some(a.clone()),
             _ => None,
         }
     }
@@ -1370,6 +1378,12 @@ impl Rc<Term> {
             .ok_or_else(|| CheckerError::ExpectedBitvector(self.clone()))
     }
 
+    /// Similar to `Term::as_string`, but returns a `CheckerError` on failure.
+    pub fn as_string_err(&self) -> Result<String, CheckerError> {
+        self.as_string()
+            .ok_or_else(|| CheckerError::ExpectedAnyString(self.clone()))
+    }
+
     /// Similar to `Term::as_fraction`, but returns a `CheckerError` on failure.
     pub fn as_fraction_err(&self) -> Result<Rational, CheckerError> {
         self.as_fraction()
@@ -1408,6 +1422,12 @@ impl Rc<Term> {
     pub fn as_let_err(&self) -> Result<(&BindingList<Rc<Term>>, &Rc<Term>), CheckerError> {
         self.as_let()
             .ok_or_else(|| CheckerError::ExpectedLetTerm(self.clone()))
+    }
+
+    /// Similar to `Term::as_automaton`, but returns a `CheckerError` on failure.
+    pub fn as_automaton_err(&self) -> Result<Automaton, CheckerError> {
+        self.as_automaton()
+            .ok_or_else(|| CheckerError::ExpectedAutomaton(self.clone()))
     }
 }
 

--- a/src/ast/term.rs
+++ b/src/ast/term.rs
@@ -1356,6 +1356,12 @@ impl Rc<Term> {
             .ok_or_else(|| CheckerError::ExpectedAnyInteger(self.clone()))
     }
 
+    /// Similar to `Term::as_signed_integer`, but returns a `CheckerError` on failure.
+    pub fn as_signed_integer_err(&self) -> Result<Integer, CheckerError> {
+        self.as_signed_integer()
+            .ok_or_else(|| CheckerError::ExpectedAnyInteger(self.clone()))
+    }
+
     /// Similar to `Term::as_integer_err`, but also checks if non-negative.
     pub fn as_usize_err(&self) -> Result<usize, CheckerError> {
         if let Some(i) = self.as_integer()

--- a/src/checker/error.rs
+++ b/src/checker/error.rs
@@ -588,6 +588,17 @@ pub enum StringError {
         got: String,
     },
 
+    #[error(
+        "regular expression index of failed: index of '{regex}' in '{s}' starting at '{index}' expected to be '{expected}', got '{got}'"
+    )]
+    RegexIndexOfFailed {
+        s: String,
+        regex: Rc<Term>,
+        index: Integer,
+        expected: Integer,
+        got: Integer,
+    },
+
     #[error("expected automata '{0}' and '{1}' to be equivalent")]
     ExpectedEquivalentAutomata(Automaton, Automaton),
 

--- a/src/checker/error.rs
+++ b/src/checker/error.rs
@@ -4,9 +4,7 @@ use crate::automata::{Automaton, Trigger};
 use crate::external::ExternalError;
 use crate::{
     ast::*,
-    automata::Trigger,
     checker::rules::linear_arithmetic::LinearComb,
-    external::ExternalError,
     utils::{Range, TypeName},
 };
 use rug::{Integer, Rational};
@@ -203,12 +201,6 @@ pub enum CheckerError {
     /// A term was expected to be a numeric constant.
     #[error("expected term '{0}' to be a numerical constant")]
     ExpectedAnyNumber(Rc<Term>),
-
-    #[error("expected term '{0}' to be a string constant")]
-    ExpectedAnyString(Rc<Term>),
-
-    #[error("expected an 'automaton' term, got '{0}'")]
-    ExpectedAutomaton(Rc<Term>),
 
     #[error("expected term '{0}' to be a string constant")]
     ExpectedAnyString(Rc<Term>),

--- a/src/checker/error.rs
+++ b/src/checker/error.rs
@@ -1,4 +1,7 @@
 //! Errors produced while checking a proof.
+
+use crate::automata::{Automaton, Trigger};
+use crate::external::ExternalError;
 use crate::{
     ast::*,
     automata::Trigger,
@@ -200,6 +203,18 @@ pub enum CheckerError {
     /// A term was expected to be a numeric constant.
     #[error("expected term '{0}' to be a numerical constant")]
     ExpectedAnyNumber(Rc<Term>),
+
+    #[error("expected term '{0}' to be a string constant")]
+    ExpectedAnyString(Rc<Term>),
+
+    #[error("expected an 'automaton' term, got '{0}'")]
+    ExpectedAutomaton(Rc<Term>),
+
+    #[error("expected term '{0}' to be a string constant")]
+    ExpectedAnyString(Rc<Term>),
+
+    #[error("expected an 'automaton' term, got '{0}'")]
+    ExpectedAutomaton(Rc<Term>),
 
     /// A term was expected to be an integer constant.
     #[error("expected term '{0}' to be an integer constant")]
@@ -551,7 +566,7 @@ pub enum SubproofError {
     OnepointWrongRightBindings(BindingList),
 }
 
-/// Errors relevant to all String rules (CPC and RCP calculus).
+/// Errors relevant to all String rules (CPC and RCP calculi).
 #[derive(Debug, Error)]
 pub enum StringError {
     #[error("expected two ranges to calculate the intersection between then, got '{0}' and '{1}'")]
@@ -580,6 +595,24 @@ pub enum StringError {
         expected: String,
         got: String,
     },
+
+    #[error("expected automata '{0}' and '{1}' to be equivalent")]
+    ExpectedEquivalentAutomata(Automaton, Automaton),
+
+    #[error("expected automaton '{0}' to be the empty intersection of '{1}' and '{2}'")]
+    ExpectedAutomataEmptyIntersection(Automaton, Automaton, Automaton),
+
+    #[error("expected non empty intersection between '{0}' and '{1}'")]
+    ExpectedAutomataIntersection(Automaton, Automaton),
+
+    #[error("expected '{0}' to be a subautomaton of '{1}'")]
+    ExpectedSubautomaton(Automaton, Automaton),
+
+    #[error("mismatched number of terms: concatenation has {0} terms, but premises have {1}")]
+    ConcatTermsNumberDiffersFromPremiseTermsNumber(usize, usize),
+
+    #[error("expected a backwardable operator, got '{0}'")]
+    NotBackwardableOperator(Rc<Term>),
 }
 
 impl From<StringError> for CheckerError {

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -130,6 +130,7 @@ pub struct ProofChecker<'c> {
     context: ContextStack,
     reached_empty_clause: bool,
     is_holey: bool,
+    automata_cache: indexmap::IndexMap<Rc<Term>, std::sync::Arc<crate::automata::Automaton>>,
     rare_rules: &'c Rules,
 }
 
@@ -142,6 +143,7 @@ impl<'c> ProofChecker<'c> {
             context: ContextStack::new(),
             reached_empty_clause: false,
             is_holey: false,
+            automata_cache: indexmap::IndexMap::new(),
             rare_rules,
         }
     }
@@ -323,6 +325,7 @@ impl<'c> ProofChecker<'c> {
             previous_command,
             discharge: &discharge,
             polyeq_time: &mut polyeq_time,
+            automata_cache: &mut self.automata_cache,
             rare_rules: self.rare_rules,
         };
 

--- a/src/checker/parallel/mod.rs
+++ b/src/checker/parallel/mod.rs
@@ -35,6 +35,7 @@ pub struct ParallelProofChecker<'c> {
     reached_empty_clause: bool,
     is_holey: bool,
     stack_size: usize,
+    automata_cache: indexmap::IndexMap<Rc<Term>, std::sync::Arc<crate::automata::Automaton>>,
     rare_rules: Rules,
 }
 
@@ -58,6 +59,7 @@ impl<'c> ParallelProofChecker<'c> {
             reached_empty_clause: false,
             is_holey: false,
             stack_size,
+            automata_cache: indexmap::IndexMap::new(),
             rare_rules,
         }
     }
@@ -72,6 +74,7 @@ impl<'c> ParallelProofChecker<'c> {
             reached_empty_clause: false,
             is_holey: false,
             stack_size: self.stack_size,
+            automata_cache: indexmap::IndexMap::new(),
             rare_rules: self.rare_rules.clone(),
         }
     }
@@ -421,6 +424,7 @@ impl<'c> ParallelProofChecker<'c> {
             previous_command,
             discharge: &discharge,
             polyeq_time: &mut polyeq_time,
+            automata_cache: &mut self.automata_cache,
             rare_rules: &self.rare_rules,
         };
 

--- a/src/checker/rules/mod.rs
+++ b/src/checker/rules/mod.rs
@@ -29,6 +29,11 @@ pub struct RuleArgs<'a> {
     pub(super) discharge: &'a [&'a ProofCommand],
 
     pub(super) polyeq_time: &'a mut Duration,
+
+    // Automatons built from regex terms by the regex-eval rules, cached across steps: proofs
+    // commonly apply many such steps to the same (hash-consed) regex.
+    pub(super) automata_cache:
+        &'a mut indexmap::IndexMap<Rc<Term>, std::sync::Arc<crate::automata::Automaton>>,
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/src/checker/rules/strings.rs
+++ b/src/checker/rules/strings.rs
@@ -1,3 +1,5 @@
+use indexmap::IndexMap;
+
 use super::{
     RuleArgs, RuleResult, assert_clause_len, assert_eq, assert_num_args, assert_num_premises,
     assert_polyeq_expected, get_premise_term,
@@ -7,9 +9,16 @@ use crate::{
         Binder, BindingList, Constant, Operator, Rc, Sort, Term, build_term, match_term,
         match_term_err, polyeq, pool::TermPool,
     },
-    checker::{error::CheckerError, rules::assert_polyeq},
+    automata::{
+        operations::{self, has_reachable_accepting_state, is_subautomaton},
+        Automaton,
+    },
+    checker::{
+        error::{CheckerError, StringError},
+        rules::assert_polyeq,
+    },
 };
-use std::{cmp, time::Duration};
+use std::{cmp, sync::Arc, time::Duration};
 
 /// A function that takes an `Rc<Term>` and returns a vector corresponding to
 /// the flat form of that term.
@@ -61,6 +70,10 @@ fn concat_extract(term: Rc<Term>) -> Vec<Rc<Term>> {
     flattened
 }
 
+/// A function to check if two flat-form string term vectors are compatible prefixes of each other.
+///
+/// It compares the elements of `s` and `t` pairwise from head to tail. If either vector is empty,
+/// they are considered compatible. If all overlapping elements match, it returns `true`; otherwise, `false`.
 fn is_compatible(s: Vec<Rc<Term>>, t: Vec<Rc<Term>>) -> bool {
     match (&s[..], &t[..]) {
         (_, []) => true,
@@ -75,6 +88,10 @@ fn is_compatible(s: Vec<Rc<Term>>, t: Vec<Rc<Term>>) -> bool {
     }
 }
 
+/// A function to compute the minimal index offset where `s` and `t` become compatible.
+///
+/// If `s` and `t` are already compatible, it returns `0`. Otherwise, it drops elements from the
+/// head of `s` recursively until a compatible suffix is found, returning the number of dropped terms.
 fn overlap(s: Vec<Rc<Term>>, t: Vec<Rc<Term>>) -> usize {
     match &s[..] {
         [] | [_] => 0,
@@ -313,18 +330,29 @@ fn string_check_length_one(term: Rc<Term>) -> Result<(), CheckerError> {
     Err(CheckerError::ExpectedStringConstantOfLengthOne(term))
 }
 
+// Skolems
+// TODO: change names later
+/// Builds a term representing the prefix of `u` of length `n`: `(str.substr u 0 n)`
 fn build_skolem_prefix(pool: &mut dyn TermPool, u: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
     build_term!(pool, (strsubstr {u.clone()} 0 {n.clone()}))
 }
 
+/// Builds a term representing the remainder suffix of `u` after dropping `n` characters:
+/// `(str.substr u n (- (str.len u) n))`.
 fn build_skolem_suffix_rem(pool: &mut dyn TermPool, u: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
     build_term!(pool, (strsubstr {u.clone()} {n.clone()} (- (strlen {u.clone()}) {n})))
 }
 
+/// Builds a term representing the suffix of `u` of length `n`:
+/// `(str.substr u (- (str.len u) n) n)`.
 fn build_skolem_suffix(pool: &mut dyn TermPool, u: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
     build_term!(pool, (strsubstr {u.clone()} (- (strlen {u.clone()}) {n.clone()}) {n.clone()}))
 }
 
+/// Builds a Skolem term for prefix unification splitting between `t` and `s`.
+///
+/// If `(str.len t) >= (str.len s)`, it extracts the suffix remainder of `t` after length `(str.len s)`;
+/// otherwise, it extracts the suffix remainder of `s` after length `(str.len t)`.
 fn build_skolem_unify_split_prefix(pool: &mut dyn TermPool, t: Rc<Term>, s: Rc<Term>) -> Rc<Term> {
     let t_len = pool.add(Term::Op(Operator::StrLen, vec![t.clone()]));
     let s_len = pool.add(Term::Op(Operator::StrLen, vec![s.clone()]));
@@ -333,6 +361,10 @@ fn build_skolem_unify_split_prefix(pool: &mut dyn TermPool, t: Rc<Term>, s: Rc<T
     build_term!(pool, (ite (>= (strlen {t.clone()}) (strlen {s.clone()})) {true_branch} {false_branch}))
 }
 
+/// Builds a Skolem term for suffix unification splitting between `t` and `s`.
+///
+/// If `(str.len t) >= (str.len s)`, it extracts the prefix of `t` of length `(- (str.len t) (str.len s))`;
+/// otherwise, it extracts the prefix of `s` of length `(- (str.len s) (str.len t))`.
 fn build_skolem_unify_split_suffix(pool: &mut dyn TermPool, t: Rc<Term>, s: Rc<Term>) -> Rc<Term> {
     let t_len = pool.add(Term::Op(Operator::StrLen, vec![t.clone()]));
     let s_len = pool.add(Term::Op(Operator::StrLen, vec![s.clone()]));
@@ -343,6 +375,8 @@ fn build_skolem_unify_split_suffix(pool: &mut dyn TermPool, t: Rc<Term>, s: Rc<T
     build_term!(pool, (ite (>= (strlen {t.clone()}) (strlen {s.clone()})) {true_branch} {false_branch}))
 }
 
+/// Builds a term extracting the suffix of string `s` of length `n`:
+/// `(str.substr s (- (str.len s) n) n)`.
 fn build_str_suffix_len(pool: &mut dyn TermPool, s: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
     build_term!(pool, (strsubstr {s.clone()} (- (strlen {s.clone()}) {n.clone()}) {n.clone()}))
 }
@@ -587,6 +621,61 @@ fn str_fixed_len_re(pool: &mut dyn TermPool, r: Rc<Term>) -> Result<usize, Check
     }
 }
 
+// RCP helper rules
+
+/// Builds the automaton for a regex term, reusing the per-proof cache: proofs
+/// commonly apply many regex-eval steps to the same (hash-consed) regex.
+fn cached_automaton(
+    pool: &mut dyn TermPool,
+    cache: &mut IndexMap<Rc<Term>, Arc<Automaton>>,
+    regex: &Rc<Term>,
+) -> Result<Arc<Automaton>, CheckerError> {
+    if let Some(a) = cache.get(regex) {
+        return Ok(a.clone());
+    }
+    let a = Arc::new(Automaton::create_from_regex_operators(pool, regex)?);
+    cache.insert(regex.clone(), a.clone());
+    Ok(a)
+}
+
+/// Constructs an automaton for a string term `t` by combining the automata from the rule premises.
+///
+/// For a concatenation term `(str.++ s_0 ... s_n)`, it verifies that each component `s_i` matches
+/// its corresponding premise `(str.in_re s_i A_i)` and builds the concatenated regular expression
+/// automaton `(re.++ A_0 ... A_n)`.
+fn make_automaton_from_string(
+    pool: &mut dyn TermPool,
+    t: &Rc<Term>,
+    premise_automatas: Vec<(Rc<Term>, Rc<Term>)>,
+) -> Result<Automaton, CheckerError> {
+    match t.as_ref() {
+        Term::Op(Operator::StrConcat, ss) => {
+            if ss.len() != premise_automatas.len() {
+                return Err(StringError::ConcatTermsNumberDiffersFromPremiseTermsNumber(
+                    ss.len(),
+                    premise_automatas.len(),
+                )
+                .into());
+            }
+
+            let mut components: Vec<Rc<Term>> = Vec::new();
+            for (index, w) in ss.iter().enumerate() {
+                let premise_a = premise_automatas[index].clone();
+                assert_eq(w, &premise_a.0)?;
+                components.push(premise_a.1.clone());
+            }
+
+            let regex_a = pool.add(Term::Op(Operator::ReConcat, components));
+            Ok(Automaton::create_from_regex_operators(pool, &regex_a)?)
+        }
+        // TODO: add other forwadable functions
+        // Term::Op(Operator::Replace, _) => {}
+        // Term::Op(Operator::ReplaceAll, _) => {}
+        _ => Err(StringError::NotBackwardableOperator(t.clone()).into()),
+    }
+}
+
+// CPC Rules (a little outdated)
 pub fn concat_eq(
     RuleArgs {
         premises,
@@ -1522,4 +1611,325 @@ pub fn re_unfold_neg_concat_fixed_suffix(
     }?;
 
     assert_eq(&conclusion[0], &expanded)
+}
+
+// RCP Rules
+pub fn re_convert(RuleArgs { conclusion, pool, .. }: RuleArgs) -> RuleResult {
+    let (w1, a1) = match_term_err!((not (strinre w a1)) = &conclusion[0])?;
+    let (w2, a2) = match_term_err!((strinre w a2) = &conclusion[1])?;
+
+    assert_eq(w1, w2)?;
+
+    let a1 = Automaton::determinize(&Automaton::create_from_regex_operators(pool, a1)?);
+    let a2 = Automaton::determinize(&a2.as_automaton_err()?);
+
+    if !operations::is_equivalent(a1.clone(), a2.clone()) {
+        return Err(StringError::ExpectedEquivalentAutomata(a1, a2).into());
+    }
+
+    Ok(())
+}
+
+pub fn re_empty_intersection(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResult {
+    let (w1, a1) = match_term_err!((not (strinre w a1)) = &conclusion[0])?;
+    let (w2, a2) = match_term_err!((not (strinre w a2)) = &conclusion[1])?;
+
+    assert_eq(w1, w2)?;
+
+    let a1 = Automaton::determinize(&a1.as_automaton_err()?);
+    let a2 = Automaton::determinize(&a2.as_automaton_err()?);
+    let intersection = operations::intersection(a1.clone(), a2.clone())?;
+
+    if has_reachable_accepting_state(&intersection) {
+        return Err(StringError::ExpectedAutomataEmptyIntersection(intersection, a1, a2).into());
+    }
+
+    Ok(())
+}
+
+pub fn re_intersection(RuleArgs { premises, conclusion, .. }: RuleArgs) -> RuleResult {
+    assert_num_premises(premises, 2..)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let mut ws: Vec<Rc<Term>> = Vec::new();
+    let mut premise_automatas: Vec<Automaton> = Vec::new();
+
+    for premise in premises {
+        let term = get_premise_term(premise)?;
+        let (w, a) = match_term_err!((strinre w a1) = term)?;
+        ws.push(w.clone());
+        premise_automatas.push(Automaton::determinize(&a.as_automaton_err()?));
+    }
+
+    let (w_conc, conc_automaton) = match_term_err!(
+        (strinre w a) = &conclusion[0]
+    )?;
+
+    let mut r = 1;
+    for l in 0..(ws.len() - 1) {
+        assert_eq(&ws[l], &ws[r])?;
+        r += 1;
+    }
+    assert_eq(&ws[r - 1], w_conc)?;
+
+    let mut expected =
+        operations::intersection(premise_automatas[0].clone(), premise_automatas[1].clone())?;
+    for automaton in premise_automatas.iter().skip(2) {
+        expected = operations::intersection(expected, automaton.clone())?;
+    }
+
+    let conc_automaton = Automaton::determinize(&conc_automaton.as_automaton_err()?);
+    if !operations::is_equivalent(expected.clone(), conc_automaton.clone()) {
+        return Err(StringError::ExpectedEquivalentAutomata(expected, conc_automaton).into());
+    }
+
+    Ok(())
+}
+
+pub fn re_forward_prop(RuleArgs { premises, conclusion, pool, .. }: RuleArgs) -> RuleResult {
+    assert_num_premises(premises, 2..)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let (s, conc_automaton) = match_term_err!(
+        (strinre s a) = &conclusion[0]
+    )?;
+
+    let mut premise_automatas: Vec<(Rc<Term>, Rc<Term>)> = Vec::new();
+    for premise in premises {
+        let term = get_premise_term(premise)?;
+        let (w, a) = match_term_err!((strinre w a) = term)?;
+        premise_automatas.push((w.clone(), a.clone()));
+    }
+
+    let expected = Automaton::determinize(&make_automaton_from_string(pool, s, premise_automatas)?);
+    let conc_automaton = Automaton::determinize(&conc_automaton.as_automaton_err()?);
+
+    if !operations::is_equivalent(expected.clone(), conc_automaton.clone()) {
+        return Err(
+            StringError::ExpectedEquivalentAutomata(expected, conc_automaton.clone()).into(),
+        );
+    }
+
+    Ok(())
+}
+
+pub fn concat_bwd_propagation(RuleArgs { premises, conclusion, pool, .. }: RuleArgs) -> RuleResult {
+    assert_num_premises(premises, 2)?;
+    assert_clause_len(conclusion, 1..)?;
+
+    let p1 = get_premise_term(&premises[0])?;
+    let p2 = get_premise_term(&premises[1])?;
+
+    let (x1, ws) = match_term_err!((= x1 (strconcat ...)) = p1)?;
+    let (x2, a) = match_term_err!((strinre x2 a) = p2)?;
+
+    assert_eq(x1, x2)?;
+
+    let a = Automaton::determinize(&Automaton::create_from_regex_operators(pool, a)?);
+
+    for and_term in conclusion {
+        let ands = match_term_err!((and ...) = and_term)?;
+        assert_eq!(&ws.len(), &ands.len());
+
+        let mut automata = Vec::new();
+        for (idx, term) in ands.iter().enumerate() {
+            let (w, re) = match_term_err!((strinre w re) = term)?;
+            assert_eq(&ws[idx], w)?;
+            automata.push(re.clone());
+        }
+
+        let re = pool.add(Term::Op(Operator::ReConcat, automata));
+        let computed = Automaton::determinize(&Automaton::create_from_regex_operators(pool, &re)?);
+
+        let intersection = operations::intersection(a.clone(), computed.clone())?;
+        if !operations::has_reachable_accepting_state(&intersection) {
+            return Err(
+                StringError::ExpectedAutomataIntersection(a.clone(), computed.clone()).into(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn concat_aut_bwd_propagation(RuleArgs { premises, conclusion, .. }: RuleArgs) -> RuleResult {
+    assert_num_premises(premises, 2)?;
+    assert_clause_len(conclusion, 1..)?;
+
+    let p1 = get_premise_term(&premises[0])?;
+    let p2 = get_premise_term(&premises[1])?;
+
+    let (x2, a) = match_term_err!((strinre x2 a) = p1)?;
+    let (x1, ws) = match_term_err!((= x1 (strconcat ...)) = p2)?;
+
+    assert_eq(x1, x2)?;
+
+    let a = a.as_automaton_err()?;
+
+    for and_term in conclusion {
+        let ands = match_term_err!((and ...) = and_term)?;
+        assert_eq!(&ws.len(), &ands.len());
+
+        for (idx, term) in ands.iter().enumerate() {
+            let (w, aut) = match_term_err!((strinre w aut) = term)?;
+            assert_eq(&ws[idx], w)?;
+
+            let aut = aut.as_automaton_err()?;
+            if !is_subautomaton(aut.clone(), a.clone()) {
+                return Err(StringError::ExpectedSubautomaton(aut, a).into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn str_replace_re_eval(
+    RuleArgs {
+        premises,
+        conclusion,
+        pool,
+        automata_cache,
+        ..
+    }: RuleArgs,
+) -> RuleResult {
+    assert_num_premises(premises, 0)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let (s, r, t, u) = match_term_err!((= (replacere s r t) u) = &conclusion[0])?;
+
+    let s = s.as_string_err()?;
+    let t = t.as_string_err()?;
+    let u = u.as_string_err()?;
+
+    let dfa = cached_automaton(pool, automata_cache, r)?;
+
+    let expected = if dfa.accepts("") {
+        format!("{}{}", t, s)
+    } else {
+        let chars: Vec<char> = s.chars().collect();
+        let n = chars.len();
+        let mut match_found = None;
+
+        'outer: for i in 0..n {
+            for j in (i + 1)..=n {
+                let substring: String = chars[i..j].iter().collect();
+                if dfa.accepts(&substring) {
+                    match_found = Some((i, j));
+                    break 'outer;
+                }
+            }
+        }
+
+        if let Some((i, j)) = match_found {
+            let prefix: String = chars[0..i].iter().collect();
+            let suffix: String = chars[j..n].iter().collect();
+            format!("{}{}{}", prefix, t, suffix)
+        } else {
+            s.clone()
+        }
+    };
+
+    if expected != u {
+        return Err(StringError::RegexReplaceFailed {
+            s,
+            regex: r.clone(),
+            replacement: t,
+            expected: u,
+            got: expected,
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+pub fn str_replace_re_all_eval(
+    RuleArgs {
+        premises,
+        conclusion,
+        pool,
+        automata_cache,
+        ..
+    }: RuleArgs,
+) -> RuleResult {
+    assert_num_premises(premises, 0)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let (s, r, t, u) = match_term_err!((= (replacereall s r t) u) = &conclusion[0])?;
+
+    let s = s.as_string_err()?;
+    let t = t.as_string_err()?;
+    let u = u.as_string_err()?;
+
+    let dfa = cached_automaton(pool, automata_cache, r)?;
+
+    let chars: Vec<char> = s.chars().collect();
+    let n = chars.len();
+    let mut result = String::new();
+    let mut index = 0;
+
+    while index < n {
+        let mut match_found = None;
+        'outer: for i in index..n {
+            for j in (i + 1)..=n {
+                let substring: String = chars[i..j].iter().collect();
+                if dfa.accepts(&substring) {
+                    match_found = Some((i, j));
+                    break 'outer;
+                }
+            }
+        }
+
+        if let Some((i, j)) = match_found {
+            let prefix: String = chars[index..i].iter().collect();
+            result.push_str(&prefix);
+            result.push_str(&t);
+            index = j;
+        } else {
+            let suffix: String = chars[index..n].iter().collect();
+            result.push_str(&suffix);
+            break;
+        }
+    }
+
+    if result != u {
+        return Err(StringError::RegexReplaceFailed {
+            s,
+            regex: r.clone(),
+            replacement: t.clone(),
+            expected: u,
+            got: result,
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+pub fn str_in_re_eval(
+    RuleArgs {
+        premises,
+        conclusion,
+        pool,
+        automata_cache,
+        ..
+    }: RuleArgs,
+) -> RuleResult {
+    assert_num_premises(premises, 0)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let (s, r, c) = match_term_err!((= (strinre s r) c) = &conclusion[0])?;
+
+    let s = s.as_string_err()?;
+    let c = c.as_bool_err()?;
+
+    let aut = cached_automaton(pool, automata_cache, r)?;
+    let accepts = aut.accepts(&s);
+
+    if accepts != c {
+        return Err(StringError::RegexMatchFailed { s, regex: r.clone(), expected: c }.into());
+    }
+
+    Ok(())
 }

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -4,14 +4,15 @@ use super::{
     RuleArgs, RuleResult, assert_clause_len, assert_eq, assert_num_args, assert_num_premises,
     assert_polyeq_expected, get_premise_term,
 };
+
 use crate::{
     ast::{
         Binder, BindingList, Constant, Operator, Rc, Sort, Term, build_term, match_term,
         match_term_err, polyeq, pool::TermPool,
     },
     automata::{
-        operations::{self, has_reachable_accepting_state, is_subautomaton},
         Automaton,
+        operations::{self, has_reachable_accepting_state, is_subautomaton},
     },
     checker::{
         error::{CheckerError, StringError},
@@ -70,39 +71,29 @@ fn concat_extract(term: Rc<Term>) -> Vec<Rc<Term>> {
     flattened
 }
 
-/// A function to check if two flat-form string term vectors are compatible prefixes of each other.
+/// A function to check if two flat-form string term slices are compatible prefixes of each other.
 ///
-/// It compares the elements of `s` and `t` pairwise from head to tail. If either vector is empty,
+/// It compares the elements of `s` and `t` pairwise from head to tail. If either slice is empty,
 /// they are considered compatible. If all overlapping elements match, it returns `true`; otherwise, `false`.
-fn is_compatible(s: Vec<Rc<Term>>, t: Vec<Rc<Term>>) -> bool {
-    match (&s[..], &t[..]) {
-        (_, []) => true,
-        ([], _) => true,
-        ([h1, t1 @ ..], [h2, t2 @ ..]) => {
-            if h1 == h2 {
-                is_compatible(t1.to_vec(), t2.to_vec())
-            } else {
-                false
-            }
-        }
-    }
+fn is_compatible(s: &[Rc<Term>], t: &[Rc<Term>]) -> bool {
+    s.iter().zip(t).all(|(a, b)| a == b)
 }
 
 /// A function to compute the minimal index offset where `s` and `t` become compatible.
 ///
 /// If `s` and `t` are already compatible, it returns `0`. Otherwise, it drops elements from the
-/// head of `s` recursively until a compatible suffix is found, returning the number of dropped terms.
-fn overlap(s: Vec<Rc<Term>>, t: Vec<Rc<Term>>) -> usize {
-    match &s[..] {
-        [] | [_] => 0,
-        [_, tail @ ..] => {
-            if is_compatible(s.clone(), t.clone()) {
-                0
-            } else {
-                1 + overlap(tail.to_vec(), t.clone())
-            }
+/// head of `s` until a compatible suffix is found, returning the number of dropped terms.
+fn overlap(s: &[Rc<Term>], t: &[Rc<Term>]) -> usize {
+    let mut current = s;
+    let mut dropped = 0;
+    while current.len() > 1 {
+        if is_compatible(current, t) {
+            return dropped;
         }
+        current = &current[1..];
+        dropped += 1;
     }
+    dropped
 }
 
 /// A function to standardize String constants and `str.++` applications
@@ -1162,11 +1153,11 @@ pub fn concat_cprop_prefix(RuleArgs { premises, conclusion, pool, .. }: RuleArgs
     };
 
     let sc = string_concat_flatten(pool, ss[0].clone());
-    let sc_tail = sc[1..].to_vec();
+    let sc_tail = sc.get(1..).unwrap_or_default();
 
     let t_2_flat = string_concat_flatten(pool, args_t[1].clone());
 
-    let v = 1 + overlap(sc_tail.clone(), t_2_flat.clone());
+    let v = 1 + overlap(sc_tail, &t_2_flat);
     let v = pool.add(Term::new_int(v));
     let oc = build_skolem_prefix(pool, ss[0].clone(), v);
     let oc_len = build_term!(pool, (strlen {oc.clone()}));
@@ -1209,12 +1200,12 @@ pub fn concat_cprop_suffix(RuleArgs { premises, conclusion, pool, .. }: RuleArgs
 
     let mut sc = string_concat_flatten(pool, ss[1].clone());
     sc.reverse();
-    let sc_tail = &sc[1..];
+    let sc_tail = sc.get(1..).unwrap_or_default();
 
     let mut t_2_flat = string_concat_flatten(pool, args_t[1].clone());
     t_2_flat.reverse();
 
-    let v = 1 + overlap(sc_tail.to_vec(), t_2_flat.clone());
+    let v = 1 + overlap(sc_tail, &t_2_flat);
     let v = pool.add(Term::new_int(v));
     let oc = build_str_suffix_len(pool, ss[1].clone(), v);
 

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -20,8 +20,9 @@ use crate::{
     },
     checker::error::{CheckerError, StringError},
 };
+use rug::Integer;
 
-// CPC rule part
+// CPC rule helper
 /// Helper function for implementing the `re_kleene_unfold_pos` and `re_concat_unfold_pos` rules.
 ///
 /// Internally handles the generation of the Skolem term resulting from `re_unfold_pos_component`,
@@ -1327,6 +1328,64 @@ pub fn concat_aut_bwd_propagation(RuleArgs { premises, conclusion, .. }: RuleArg
                 return Err(StringError::ExpectedSubautomaton(aut, a).into());
             }
         }
+    }
+
+    Ok(())
+}
+
+pub fn str_indexof_re_eval(
+    RuleArgs {
+        premises,
+        conclusion,
+        pool,
+        automata_cache,
+        ..
+    }: RuleArgs,
+) -> RuleResult {
+    assert_num_premises(premises, 0)?;
+    assert_clause_len(conclusion, 1)?;
+
+    let (s, r, n, m) = match_term_err!((= (indexofre s r n) m) = &conclusion[0])?;
+
+    let s = s.as_string_err()?;
+    let dfa = cached_automaton(pool, automata_cache, r)?;
+    let n = n.as_signed_integer_err()?;
+    let m = m.as_signed_integer_err()?;
+
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+
+    let expected: Integer = if n < 0 || n > len {
+        Integer::from(-1)
+    } else if dfa.accepts("") {
+        n.clone()
+    } else {
+        let start_idx = n.to_usize().unwrap();
+        let mut match_pos = None;
+        'outer: for i in start_idx..len {
+            for j in (i + 1)..=len {
+                let substring: String = chars[i..j].iter().collect();
+                if dfa.accepts(&substring) {
+                    match_pos = Some(i);
+                    break 'outer;
+                }
+            }
+        }
+        match match_pos {
+            Some(i) => Integer::from(i),
+            None => Integer::from(-1),
+        }
+    };
+
+    if expected != m {
+        return Err(StringError::RegexIndexOfFailed {
+            s,
+            regex: r.clone(),
+            index: n,
+            expected: m,
+            got: expected,
+        }
+        .into());
     }
 
     Ok(())

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -1,376 +1,25 @@
-use indexmap::IndexMap;
+pub mod normalization;
+pub mod utils;
 
 use super::{
     RuleArgs, RuleResult, assert_clause_len, assert_eq, assert_num_args, assert_num_premises,
-    assert_polyeq_expected, get_premise_term,
+    assert_polyeq, get_premise_term,
 };
 
 use crate::{
     ast::{
-        Binder, BindingList, Constant, Operator, Rc, Sort, Term, build_term, match_term,
-        match_term_err, polyeq, pool::TermPool,
+        Binder, BindingList, Constant, Operator, Rc, Sort, Term, build_term, match_term_err,
+        pool::TermPool,
     },
     automata::{
         Automaton,
         operations::{self, has_reachable_accepting_state, is_subautomaton},
     },
-    checker::{
-        error::{CheckerError, StringError},
-        rules::assert_polyeq,
-    },
+    checker::error::{CheckerError, StringError},
 };
-use std::{cmp, sync::Arc, time::Duration};
 
-/// A function that takes an `Rc<Term>` and returns a vector corresponding to
-/// the flat form of that term.
-///
-/// In this flat form, all `str.++` applications are dissolved and every
-/// argument of those applications is inserted into the vector (e.g., `(str.++
-/// a (str.++ b c))` would lead to `[a, b, c]`, where `a`, `b` and `c` are
-/// arbitrary String terms). Furthermore, all String constants are broken
-/// into constants of size one and are inserted into the vector too.
-///
-/// All String terms that aren't `str.++` applications can be seen as `(str.++ term "")`.
-/// So, applying `flatten` to them would lead to `[term]`. Furthermore,
-/// the empty String isn't mapped to any entry in the vector, so `flatten`
-/// applied to `""` leads to an empty vector.
-fn string_concat_flatten(pool: &mut dyn TermPool, term: Rc<Term>) -> Vec<Rc<Term>> {
-    let mut flattened = Vec::new();
-    if let Term::Const(Constant::String(s)) = term.as_ref() {
-        flattened.extend(
-            s.chars()
-                .map(|c| pool.add(Term::Const(Constant::String(c.to_string())))),
-        );
-    } else if let Some(args) = match_term!((strconcat ...) = term) {
-        for arg in args {
-            flattened.extend(string_concat_flatten(pool, arg.clone()));
-        }
-    } else {
-        flattened.push(term.clone());
-    }
-    flattened
-}
-
-/// A function that takes an `Rc<Term>` and returns a vector corresponding to
-/// the flat form of that term.
-///
-/// It works almost the same as `string_concat_flatten`, but it does not split string constants.
-fn concat_extract(term: Rc<Term>) -> Vec<Rc<Term>> {
-    let mut flattened = Vec::new();
-    if let Term::Const(Constant::String(s)) = term.as_ref() {
-        if !s.is_empty() {
-            flattened.push(term.clone());
-        }
-    } else if let Some(args) = match_term!((strconcat ...) = term) {
-        for arg in args {
-            flattened.extend(concat_extract(arg.clone()));
-        }
-    } else {
-        flattened.push(term.clone());
-    }
-    flattened
-}
-
-/// A function to check if two flat-form string term slices are compatible prefixes of each other.
-///
-/// It compares the elements of `s` and `t` pairwise from head to tail. If either slice is empty,
-/// they are considered compatible. If all overlapping elements match, it returns `true`; otherwise, `false`.
-fn is_compatible(s: &[Rc<Term>], t: &[Rc<Term>]) -> bool {
-    s.iter().zip(t).all(|(a, b)| a == b)
-}
-
-/// A function to compute the minimal index offset where `s` and `t` become compatible.
-///
-/// If `s` and `t` are already compatible, it returns `0`. Otherwise, it drops elements from the
-/// head of `s` until a compatible suffix is found, returning the number of dropped terms.
-fn overlap(s: &[Rc<Term>], t: &[Rc<Term>]) -> usize {
-    let mut current = s;
-    let mut dropped = 0;
-    while current.len() > 1 {
-        if is_compatible(current, t) {
-            return dropped;
-        }
-        current = &current[1..];
-        dropped += 1;
-    }
-    dropped
-}
-
-/// A function to standardize String constants and `str.++` applications
-/// across a term.
-///
-/// It takes an `Rc<Term>` and returns an equivalent `Rc<Term>` where all String
-/// constants of size greater than one are broken into `str.++` applications
-/// of their characters (`"abc"` would become `(str.++ "a" "b" "c")`), and
-/// nested `str.++` applications are dissolved, remaining just one application
-/// with all the previous nested arguments (e.g., `(str.++ a (str.++ b (str.++ c "")))` would lead to `(str.++ a b c)`).
-fn expand_string_constants(pool: &mut dyn TermPool, term: &Rc<Term>) -> Rc<Term> {
-    match term.as_ref() {
-        Term::Const(Constant::String(s)) => {
-            let args: Vec<Rc<Term>> = s
-                .chars()
-                .map(|c| pool.add(Term::Const(Constant::String(c.to_string()))))
-                .collect();
-            match args.len() {
-                0 => pool.add(Term::new_string("")),
-                1 => args[0].clone(),
-                _ => pool.add(Term::Op(Operator::StrConcat, args)),
-            }
-        }
-        Term::Op(op, args) => match op {
-            Operator::StrConcat => {
-                let mut new_args = Vec::new();
-                // (str.++ "a" (str.++ "b" "c")) => (str.++ "a" "b" "c")
-                for arg in args {
-                    new_args.extend(string_concat_flatten(pool, arg.clone()));
-                }
-                pool.add(Term::Op(*op, new_args))
-            }
-            _ => {
-                let new_args = args
-                    .iter()
-                    .map(|a| expand_string_constants(pool, a))
-                    .collect();
-                pool.add(Term::Op(*op, new_args))
-            }
-        },
-        Term::App(func, args) => {
-            let new_args = args
-                .iter()
-                .map(|term| expand_string_constants(pool, term))
-                .collect();
-            pool.add(Term::App(func.clone(), new_args))
-        }
-        Term::Let(binding, inner) => {
-            let new_inner = expand_string_constants(pool, inner);
-            pool.add(Term::Let(binding.clone(), new_inner))
-        }
-        Term::Binder(q, bindings, inner) => {
-            let new_inner = expand_string_constants(pool, inner);
-            pool.add(Term::Binder(*q, bindings.clone(), new_inner))
-        }
-        Term::ParamOp { op, op_args, args } => {
-            let new_args = args
-                .iter()
-                .map(|term| expand_string_constants(pool, term))
-                .collect();
-            pool.add(Term::ParamOp {
-                op: *op,
-                op_args: op_args.clone(),
-                args: new_args,
-            })
-        }
-        Term::AsOp(op, sort, args) => {
-            let new_args = args
-                .iter()
-                .map(|term| expand_string_constants(pool, term))
-                .collect();
-            pool.add(Term::AsOp(*op, sort.clone(), new_args))
-        }
-        Term::Match(t, cases) => {
-            let new_t = expand_string_constants(pool, t);
-            let new_cases = cases
-                .iter()
-                .map(|case| crate::ast::MatchCase {
-                    pattern: case.pattern.clone(),
-                    body: expand_string_constants(pool, &case.body),
-                })
-                .collect();
-            pool.add(Term::Match(new_t, new_cases))
-        }
-        Term::Var(..) | Term::Const(_) => term.clone(),
-    }
-}
-
-/// A function to reconstruct a term given its flat form.
-///
-/// It takes a vector of `Rc<Term>` and returns a new term based on the length
-/// of the flat form vector. If the vector is empty, it's equivalent to the
-/// empty String. If the length is equal to one, the only term of the vector
-/// is returned. Finally, if the length is greater than one, an `str.++`
-/// application is returned with the flat form vector as its arguments (e.g.,
-/// `[a, "b", c]` would lead to `(str.++ a "b" c)`, where `a` and `c` are
-/// arbitrary terms).
-fn concat(pool: &mut dyn TermPool, terms: Vec<Rc<Term>>) -> Rc<Term> {
-    match terms.len() {
-        0 => pool.add(Term::new_string("")),
-        1 => terms[0].clone(),
-        _ => pool.add(Term::Op(Operator::StrConcat, terms)),
-    }
-}
-
-/// A function to check if a term is a prefix or suffix of another.
-///
-/// It takes two `Rc<Term>` and a reverse parameter. If the reverse parameter is
-/// set to `false`, it checks if the second term is a prefix of the first one,
-/// and if it's set to `true`, it checks if it's a suffix.
-///
-/// The function throws an error if the prefix/suffix is larger than the main
-/// term. It returns the prefix/suffix in flat form if the check was successful.
-fn is_prefix_or_suffix(
-    pool: &mut dyn TermPool,
-    term: Rc<Term>,
-    pref: Rc<Term>,
-    rev: bool,
-    polyeq_time: &mut Duration,
-) -> Result<Vec<Rc<Term>>, CheckerError> {
-    let mut t_flat = string_concat_flatten(pool, term.clone());
-    let mut p_flat = string_concat_flatten(pool, pref.clone());
-    if rev {
-        t_flat.reverse();
-        p_flat.reverse();
-    }
-    if p_flat.len() > t_flat.len() {
-        if rev {
-            return Err(CheckerError::ExpectedToBeSuffix(pref, term));
-        } else {
-            return Err(CheckerError::ExpectedToBePrefix(pref, term));
-        }
-    }
-    for (i, el) in p_flat.iter().enumerate() {
-        assert_polyeq_expected(el, t_flat[i].clone(), polyeq_time)?;
-    }
-    if rev {
-        p_flat.reverse();
-    }
-    Ok(p_flat)
-}
-
-/// An application of `is_prefix_or_suffix` where the reverse parameter is set
-/// to `false` by default.
-fn is_prefix(
-    pool: &mut dyn TermPool,
-    term: Rc<Term>,
-    pref: Rc<Term>,
-    polyeq_time: &mut Duration,
-) -> Result<Vec<Rc<Term>>, CheckerError> {
-    is_prefix_or_suffix(pool, term, pref, false, polyeq_time)
-}
-
-/// An application of `is_prefix_or_suffix` where the reverse parameter is set
-/// to `true` by default.
-fn is_suffix(
-    pool: &mut dyn TermPool,
-    term: Rc<Term>,
-    pref: Rc<Term>,
-    polyeq_time: &mut Duration,
-) -> Result<Vec<Rc<Term>>, CheckerError> {
-    is_prefix_or_suffix(pool, term, pref, true, polyeq_time)
-}
-
-type Suffixes = (Vec<Rc<Term>>, Vec<Rc<Term>>);
-
-/// A function to remove the longest common prefix or suffix.
-///
-/// It takes two `Rc<Term>` and a reverse parameter. If the parameter is set to
-/// `false`, it removes the longest common prefix, and if it's set to `true`,
-/// the longest common suffix.
-///
-/// The function throws an error if the terms aren't `str.++` applications.
-/// It returns two vectors with the remaining terms after the removal in flat
-/// form (e.g., the remaining suffixes after a prefix removal or vice versa).
-///
-/// If the terms don't share common prefixes or suffixes, the function
-/// doesn't remove anything, so the tuple returned is the flat form for both of
-/// them.
-fn strip_prefix_or_suffix(
-    pool: &mut dyn TermPool,
-    s: Rc<Term>,
-    t: Rc<Term>,
-    rev: bool,
-    polyeq_time: &mut Duration,
-) -> Result<Suffixes, CheckerError> {
-    let mut s_flat = string_concat_flatten(pool, s.clone());
-    let mut t_flat = string_concat_flatten(pool, t.clone());
-    if rev {
-        s_flat.reverse();
-        t_flat.reverse();
-    }
-    if s_flat.is_empty() {
-        return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s));
-    }
-    if t_flat.is_empty() {
-        return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t));
-    }
-    let mut prefix = 0;
-    while (prefix < cmp::min(s_flat.len(), t_flat.len()))
-        && polyeq(&s_flat[prefix], &t_flat[prefix], polyeq_time)
-    {
-        prefix += 1;
-    }
-    let mut s_suffix = s_flat.get(prefix..).unwrap_or_default().to_vec();
-    let mut t_suffix = t_flat.get(prefix..).unwrap_or_default().to_vec();
-    if rev {
-        s_suffix.reverse();
-        t_suffix.reverse();
-    }
-    Ok((s_suffix, t_suffix))
-}
-
-/// A function to check if a String has a length equal to one.
-///
-/// It takes an `Rc<Term>` and throws an error if the term isn't a String
-/// constant (we can't compute lengths properly in this case) or isn't a String
-/// constant of size one.
-fn string_check_length_one(term: Rc<Term>) -> Result<(), CheckerError> {
-    if let Term::Const(Constant::String(s)) = term.as_ref()
-        && s.len() == 1
-    {
-        return Ok(());
-    }
-    Err(CheckerError::ExpectedStringConstantOfLengthOne(term))
-}
-
-// Skolems
-// TODO: change names later
-/// Builds a term representing the prefix of `u` of length `n`: `(str.substr u 0 n)`
-fn build_skolem_prefix(pool: &mut dyn TermPool, u: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
-    build_term!(pool, (strsubstr {u.clone()} 0 {n.clone()}))
-}
-
-/// Builds a term representing the remainder suffix of `u` after dropping `n` characters:
-/// `(str.substr u n (- (str.len u) n))`.
-fn build_skolem_suffix_rem(pool: &mut dyn TermPool, u: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
-    build_term!(pool, (strsubstr {u.clone()} {n.clone()} (- (strlen {u.clone()}) {n})))
-}
-
-/// Builds a term representing the suffix of `u` of length `n`:
-/// `(str.substr u (- (str.len u) n) n)`.
-fn build_skolem_suffix(pool: &mut dyn TermPool, u: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
-    build_term!(pool, (strsubstr {u.clone()} (- (strlen {u.clone()}) {n.clone()}) {n.clone()}))
-}
-
-/// Builds a Skolem term for prefix unification splitting between `t` and `s`.
-///
-/// If `(str.len t) >= (str.len s)`, it extracts the suffix remainder of `t` after length `(str.len s)`;
-/// otherwise, it extracts the suffix remainder of `s` after length `(str.len t)`.
-fn build_skolem_unify_split_prefix(pool: &mut dyn TermPool, t: Rc<Term>, s: Rc<Term>) -> Rc<Term> {
-    let t_len = pool.add(Term::Op(Operator::StrLen, vec![t.clone()]));
-    let s_len = pool.add(Term::Op(Operator::StrLen, vec![s.clone()]));
-    let true_branch = build_skolem_suffix_rem(pool, t.clone(), s_len).clone();
-    let false_branch = build_skolem_suffix_rem(pool, s.clone(), t_len).clone();
-    build_term!(pool, (ite (>= (strlen {t.clone()}) (strlen {s.clone()})) {true_branch} {false_branch}))
-}
-
-/// Builds a Skolem term for suffix unification splitting between `t` and `s`.
-///
-/// If `(str.len t) >= (str.len s)`, it extracts the prefix of `t` of length `(- (str.len t) (str.len s))`;
-/// otherwise, it extracts the prefix of `s` of length `(- (str.len s) (str.len t))`.
-fn build_skolem_unify_split_suffix(pool: &mut dyn TermPool, t: Rc<Term>, s: Rc<Term>) -> Rc<Term> {
-    let t_len = pool.add(Term::Op(Operator::StrLen, vec![t.clone()]));
-    let s_len = pool.add(Term::Op(Operator::StrLen, vec![s.clone()]));
-    let n_t = build_term!(pool, (- {t_len.clone()} {s_len.clone()}));
-    let n_s = build_term!(pool, (- {s_len.clone()} {t_len.clone()}));
-    let true_branch = build_skolem_prefix(pool, t.clone(), n_t).clone();
-    let false_branch = build_skolem_prefix(pool, s.clone(), n_s).clone();
-    build_term!(pool, (ite (>= (strlen {t.clone()}) (strlen {s.clone()})) {true_branch} {false_branch}))
-}
-
-/// Builds a term extracting the suffix of string `s` of length `n`:
-/// `(str.substr s (- (str.len s) n) n)`.
-fn build_str_suffix_len(pool: &mut dyn TermPool, s: Rc<Term>, n: Rc<Term>) -> Rc<Term> {
-    build_term!(pool, (strsubstr {s.clone()} (- (strlen {s.clone()}) {n.clone()}) {n.clone()}))
-}
+pub use normalization::NormalizedConcat;
+pub use utils::*;
 
 /// Helper function to properly extract the arguments of the `concat_cprop` rule.
 fn extract_arguments(t: &Rc<Term>) -> Result<Vec<Rc<Term>>, CheckerError> {
@@ -612,60 +261,6 @@ fn str_fixed_len_re(pool: &mut dyn TermPool, r: Rc<Term>) -> Result<usize, Check
     }
 }
 
-// RCP helper rules
-
-/// Builds the automaton for a regex term, reusing the per-proof cache: proofs
-/// commonly apply many regex-eval steps to the same (hash-consed) regex.
-fn cached_automaton(
-    pool: &mut dyn TermPool,
-    cache: &mut IndexMap<Rc<Term>, Arc<Automaton>>,
-    regex: &Rc<Term>,
-) -> Result<Arc<Automaton>, CheckerError> {
-    if let Some(a) = cache.get(regex) {
-        return Ok(a.clone());
-    }
-    let a = Arc::new(Automaton::create_from_regex_operators(pool, regex)?);
-    cache.insert(regex.clone(), a.clone());
-    Ok(a)
-}
-
-/// Constructs an automaton for a string term `t` by combining the automata from the rule premises.
-///
-/// For a concatenation term `(str.++ s_0 ... s_n)`, it verifies that each component `s_i` matches
-/// its corresponding premise `(str.in_re s_i A_i)` and builds the concatenated regular expression
-/// automaton `(re.++ A_0 ... A_n)`.
-fn make_automaton_from_string(
-    pool: &mut dyn TermPool,
-    t: &Rc<Term>,
-    premise_automatas: Vec<(Rc<Term>, Rc<Term>)>,
-) -> Result<Automaton, CheckerError> {
-    match t.as_ref() {
-        Term::Op(Operator::StrConcat, ss) => {
-            if ss.len() != premise_automatas.len() {
-                return Err(StringError::ConcatTermsNumberDiffersFromPremiseTermsNumber(
-                    ss.len(),
-                    premise_automatas.len(),
-                )
-                .into());
-            }
-
-            let mut components: Vec<Rc<Term>> = Vec::new();
-            for (index, w) in ss.iter().enumerate() {
-                let premise_a = premise_automatas[index].clone();
-                assert_eq(w, &premise_a.0)?;
-                components.push(premise_a.1.clone());
-            }
-
-            let regex_a = pool.add(Term::Op(Operator::ReConcat, components));
-            Ok(Automaton::create_from_regex_operators(pool, &regex_a)?)
-        }
-        // TODO: add other forwadable functions
-        // Term::Op(Operator::Replace, _) => {}
-        // Term::Op(Operator::ReplaceAll, _) => {}
-        _ => Err(StringError::NotBackwardableOperator(t.clone()).into()),
-    }
-}
-
 // CPC Rules (a little outdated)
 pub fn concat_eq(
     RuleArgs {
@@ -687,15 +282,15 @@ pub fn concat_eq(
     let rev = args[0].as_bool_err()?;
     let (s, t) = match_term_err!((= s t) = term)?;
 
-    let (ss, ts) = strip_prefix_or_suffix(pool, s.clone(), t.clone(), rev, polyeq_time)?;
-    let ss_concat = concat(pool, ss);
-    let ts_concat = concat(pool, ts);
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let (ss, ts) = s_norm.strip_prefix_or_suffix(&t_norm, s, t, rev, polyeq_time)?;
     let expected = build_term!(
         pool,
-        (= {ss_concat.clone()} {ts_concat.clone()})
+        (= {ss.into_term(pool)} {ts.into_term(pool)})
     );
 
-    let expanded = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -722,16 +317,22 @@ pub fn concat_unify(
     let (s, t) = match_term_err!((= s t) = term)?;
     let (s_1, t_1) = match_term_err!((= (strlen s_1) (strlen t_1)) = prefixes)?;
 
-    let s_1 = is_prefix_or_suffix(pool, s.clone(), s_1.clone(), rev, polyeq_time)?;
-    let t_1 = is_prefix_or_suffix(pool, t.clone(), t_1.clone(), rev, polyeq_time)?;
-    let s_concat = concat(pool, s_1);
-    let t_concat = concat(pool, t_1);
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let s_1_norm = NormalizedConcat::from_term(pool, s_1);
+    let t_1_norm = NormalizedConcat::from_term(pool, t_1);
+
+    s_1_norm.assert_is_prefix_or_suffix_of(&s_norm, s_1, s, rev, polyeq_time)?;
+    t_1_norm.assert_is_prefix_or_suffix_of(&t_norm, t_1, t, rev, polyeq_time)?;
+
+    let s_concat = s_1_norm.into_term(pool);
+    let t_concat = t_1_norm.into_term(pool);
     let expected = build_term!(
         pool,
-        (= {s_concat.clone()} {t_concat.clone()})
+        (= {s_concat} {t_concat})
     );
 
-    let expanded = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -760,19 +361,21 @@ pub fn concat_conflict(
     }
 
     let (s, t) = match_term_err!((= s t) = term)?;
-    let (mut ss, mut ts) = strip_prefix_or_suffix(pool, s.clone(), t.clone(), rev, polyeq_time)?;
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let (mut ss, mut ts) = s_norm.strip_prefix_or_suffix(&t_norm, s, t, rev, polyeq_time)?;
     if rev {
         ss.reverse();
         ts.reverse();
     }
 
     if let Some(ss_head) = ss.first() {
-        string_check_length_one(ss_head.clone())?;
+        NormalizedConcat::assert_length_one(ss_head)?;
         if let Some(ts_head) = ts.first() {
-            string_check_length_one(ts_head.clone())?;
+            NormalizedConcat::assert_length_one(ts_head)?;
         }
     } else if let Some(ts_head) = ts.first() {
-        string_check_length_one(ts_head.clone())?;
+        NormalizedConcat::assert_length_one(ts_head)?;
     } else {
         return Err(CheckerError::ExpectedDifferentConstantPrefixes(
             s.clone(),
@@ -802,31 +405,33 @@ pub fn concat_csplit_prefix(
     let (t, s) = match_term_err!((= t s) = terms)?;
     let t_1 = match_term_err!((not (= (strlen t_1) 0)) = length)?;
 
-    let s_flat = string_concat_flatten(pool, s.clone());
-    if string_concat_flatten(pool, t.clone()).is_empty() {
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    if t_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t.clone()));
     }
-    if s_flat.is_empty() {
+    if s_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s.clone()));
     }
 
-    is_prefix(pool, t.clone(), t_1.clone(), polyeq_time)?;
+    let t_1_norm = NormalizedConcat::from_term(pool, t_1);
+    t_1_norm.assert_is_prefix_of(&t_norm, t_1, t, polyeq_time)?;
     let mut right_eq: Vec<Rc<Term>> = vec![];
-    if let Some(c) = s_flat.first() {
-        string_check_length_one(c.clone())?;
+    if let Some(c) = s_norm.first() {
+        NormalizedConcat::assert_length_one(c)?;
         right_eq.push(c.clone());
         let n = pool.add(Term::new_int(1));
-        right_eq.push(build_skolem_suffix_rem(pool, t_1.clone(), n).clone());
+        right_eq.push(pool.build_str_suffix_rem(t_1, &n));
     }
 
-    let t_1 = expand_string_constants(pool, t_1);
-    let right_eq_concat = concat(pool, right_eq);
+    let t_1 = NormalizedConcat::expand_constants(pool, t_1);
+    let right_eq_concat = NormalizedConcat::new(right_eq).into_term(pool);
     let expected = build_term!(
         pool,
-        (= {t_1.clone()} {right_eq_concat.clone()})
+        (= {t_1} {right_eq_concat})
     );
 
-    let expanded = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -850,31 +455,33 @@ pub fn concat_csplit_suffix(
     let (t, s) = match_term_err!((= t s) = terms)?;
     let t_2 = match_term_err!((not (= (strlen t_2) 0)) = length)?;
 
-    let s_flat = string_concat_flatten(pool, s.clone());
-    if string_concat_flatten(pool, t.clone()).is_empty() {
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    if t_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t.clone()));
     }
-    if s_flat.is_empty() {
+    if s_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s.clone()));
     }
 
-    is_suffix(pool, t.clone(), t_2.clone(), polyeq_time)?;
+    let t_2_norm = NormalizedConcat::from_term(pool, t_2);
+    t_2_norm.assert_is_suffix_of(&t_norm, t_2, t, polyeq_time)?;
     let mut right_eq: Vec<Rc<Term>> = vec![];
-    if let Some(c) = s_flat.last() {
-        string_check_length_one(c.clone())?;
+    if let Some(c) = s_norm.last() {
+        NormalizedConcat::assert_length_one(c)?;
         let n = build_term!(pool, (- (strlen {t_2.clone()}) 1));
-        right_eq.push(build_skolem_prefix(pool, t_2.clone(), n).clone());
+        right_eq.push(pool.build_str_prefix(t_2, &n));
         right_eq.push(c.clone());
     }
 
-    let t_2 = expand_string_constants(pool, t_2);
-    let right_eq_concat = concat(pool, right_eq);
+    let t_2 = NormalizedConcat::expand_constants(pool, t_2);
+    let right_eq_concat = NormalizedConcat::new(right_eq).into_term(pool);
     let expected = build_term!(
         pool,
-        (= {t_2.clone()} {right_eq_concat.clone()})
+        (= {t_2} {right_eq_concat})
     );
 
-    let expanded = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -904,18 +511,22 @@ pub fn concat_split_prefix(
     let (t, s) = match_term_err!((= t s) = terms)?;
     let (t_1, s_1) = match_term_err!((not (= (strlen t_1) (strlen s_1))) = length)?;
 
-    if string_concat_flatten(pool, t.clone()).is_empty() {
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    if t_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t.clone()));
     }
-    if string_concat_flatten(pool, s.clone()).is_empty() {
+    if s_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s.clone()));
     }
 
-    is_prefix(pool, t.clone(), t_1.clone(), polyeq_time)?;
-    is_prefix(pool, s.clone(), s_1.clone(), polyeq_time)?;
-    let t_1 = expand_string_constants(pool, t_1);
-    let s_1 = expand_string_constants(pool, s_1);
-    let r = build_skolem_unify_split_prefix(pool, t_1.clone(), s_1.clone());
+    let t_1_norm = NormalizedConcat::from_term(pool, t_1);
+    let s_1_norm = NormalizedConcat::from_term(pool, s_1);
+    t_1_norm.assert_is_prefix_of(&t_norm, t_1, t, polyeq_time)?;
+    s_1_norm.assert_is_prefix_of(&s_norm, s_1, s, polyeq_time)?;
+    let t_1 = NormalizedConcat::expand_constants(pool, t_1);
+    let s_1 = NormalizedConcat::expand_constants(pool, s_1);
+    let r = pool.build_str_unify_split_prefix(&t_1, &s_1);
 
     let or = build_term!(
         pool,
@@ -935,14 +546,14 @@ pub fn concat_split_prefix(
     let expanded = build_term!(
         pool,
         (and
-            {or.clone()}
-            (not (= {r.clone()} {empty.clone()}))
-            (> (strlen {r.clone()}) 0)
+            {or}
+            (not (= {r.clone()} {empty}))
+            (> (strlen {r}) 0)
         )
     );
 
-    let expanded = expand_string_constants(pool, &expanded);
-    let expected = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &expanded);
+    let expected = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -972,18 +583,22 @@ pub fn concat_split_suffix(
     let (t, s) = match_term_err!((= t s) = terms)?;
     let (t_2, s_2) = match_term_err!((not (= (strlen t_2) (strlen s_2))) = length)?;
 
-    if string_concat_flatten(pool, t.clone()).is_empty() {
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    if t_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t.clone()));
     }
-    if string_concat_flatten(pool, s.clone()).is_empty() {
+    if s_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s.clone()));
     }
 
-    is_suffix(pool, t.clone(), t_2.clone(), polyeq_time)?;
-    is_suffix(pool, s.clone(), s_2.clone(), polyeq_time)?;
-    let t_2 = expand_string_constants(pool, t_2);
-    let s_2 = expand_string_constants(pool, s_2);
-    let r = build_skolem_unify_split_suffix(pool, t_2.clone(), s_2.clone());
+    let t_2_norm = NormalizedConcat::from_term(pool, t_2);
+    let s_2_norm = NormalizedConcat::from_term(pool, s_2);
+    t_2_norm.assert_is_suffix_of(&t_norm, t_2, t, polyeq_time)?;
+    s_2_norm.assert_is_suffix_of(&s_norm, s_2, s, polyeq_time)?;
+    let t_2 = NormalizedConcat::expand_constants(pool, t_2);
+    let s_2 = NormalizedConcat::expand_constants(pool, s_2);
+    let r = pool.build_str_unify_split_suffix(&t_2, &s_2);
 
     let or = build_term!(
         pool,
@@ -1003,14 +618,14 @@ pub fn concat_split_suffix(
     let expanded = build_term!(
         pool,
         (and
-            {or.clone()}
-            (not (= {r.clone()} {empty.clone()}))
-            (> (strlen {r.clone()}) 0)
+            {or}
+            (not (= {r.clone()} {empty}))
+            (> (strlen {r}) 0)
         )
     );
 
-    let expanded = expand_string_constants(pool, &expanded);
-    let expected = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &expanded);
+    let expected = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -1040,32 +655,36 @@ pub fn concat_lprop_prefix(
     let (t, s) = match_term_err!((= t s) = terms)?;
     let (t_1, s_1) = match_term_err!((> (strlen t_1) (strlen s_1)) = length)?;
 
-    if string_concat_flatten(pool, t.clone()).is_empty() {
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    if t_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t.clone()));
     }
-    if string_concat_flatten(pool, s.clone()).is_empty() {
+    if s_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s.clone()));
     }
 
-    is_prefix(pool, t.clone(), t_1.clone(), polyeq_time)?;
-    is_prefix(pool, s.clone(), s_1.clone(), polyeq_time)?;
-    let t_1 = expand_string_constants(pool, t_1);
-    let s_1 = expand_string_constants(pool, s_1);
-    let r = build_skolem_unify_split_prefix(pool, t_1.clone(), s_1.clone());
+    let t_1_norm = NormalizedConcat::from_term(pool, t_1);
+    let s_1_norm = NormalizedConcat::from_term(pool, s_1);
+    t_1_norm.assert_is_prefix_of(&t_norm, t_1, t, polyeq_time)?;
+    s_1_norm.assert_is_prefix_of(&s_norm, s_1, s, polyeq_time)?;
+    let t_1 = NormalizedConcat::expand_constants(pool, t_1);
+    let s_1 = NormalizedConcat::expand_constants(pool, s_1);
+    let r = pool.build_str_unify_split_prefix(&t_1, &s_1);
 
-    let eq = build_term!(pool, (strconcat {s_1.clone()} {r.clone()}));
+    let eq = build_term!(pool, (strconcat {s_1} {r.clone()}));
     let empty = pool.add(Term::new_string(""));
     let expanded = build_term!(
         pool,
         (and
-            (= {t_1.clone()} {eq.clone()})
-            (not (= {r.clone()} {empty.clone()}))
-            (> (strlen {r.clone()}) 0)
+            (= {t_1} {eq})
+            (not (= {r.clone()} {empty}))
+            (> (strlen {r}) 0)
         )
     );
 
-    let expanded = expand_string_constants(pool, &expanded);
-    let expected = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &expanded);
+    let expected = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -1095,32 +714,36 @@ pub fn concat_lprop_suffix(
     let (t, s) = match_term_err!((= t s) = terms)?;
     let (t_2, s_2) = match_term_err!((> (strlen t_2) (strlen s_2)) = length)?;
 
-    if string_concat_flatten(pool, t.clone()).is_empty() {
+    let t_norm = NormalizedConcat::from_term(pool, t);
+    let s_norm = NormalizedConcat::from_term(pool, s);
+    if t_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", t.clone()));
     }
-    if string_concat_flatten(pool, s.clone()).is_empty() {
+    if s_norm.is_empty() {
         return Err(CheckerError::TermOfWrongForm("(str.++ ...)", s.clone()));
     }
 
-    is_suffix(pool, t.clone(), t_2.clone(), polyeq_time)?;
-    is_suffix(pool, s.clone(), s_2.clone(), polyeq_time)?;
-    let t_2 = expand_string_constants(pool, t_2);
-    let s_2 = expand_string_constants(pool, s_2);
-    let r = build_skolem_unify_split_suffix(pool, t_2.clone(), s_2.clone());
+    let t_2_norm = NormalizedConcat::from_term(pool, t_2);
+    let s_2_norm = NormalizedConcat::from_term(pool, s_2);
+    t_2_norm.assert_is_suffix_of(&t_norm, t_2, t, polyeq_time)?;
+    s_2_norm.assert_is_suffix_of(&s_norm, s_2, s, polyeq_time)?;
+    let t_2 = NormalizedConcat::expand_constants(pool, t_2);
+    let s_2 = NormalizedConcat::expand_constants(pool, s_2);
+    let r = pool.build_str_unify_split_suffix(&t_2, &s_2);
 
-    let eq = build_term!(pool, (strconcat {r.clone()} {s_2.clone()}));
+    let eq = build_term!(pool, (strconcat {r.clone()} {s_2}));
     let empty = pool.add(Term::new_string(""));
     let expanded = build_term!(
         pool,
         (and
-            (= {t_2.clone()} {eq.clone()})
-            (not (= {r.clone()} {empty.clone()}))
-            (> (strlen {r.clone()}) 0)
+            (= {t_2} {eq})
+            (not (= {r.clone()} {empty}))
+            (> (strlen {r}) 0)
         )
     );
 
-    let expanded = expand_string_constants(pool, &expanded);
-    let expected = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &expanded);
+    let expected = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -1152,21 +775,21 @@ pub fn concat_cprop_prefix(RuleArgs { premises, conclusion, pool, .. }: RuleArgs
         _ => return Err(CheckerError::TermOfWrongForm("(str.++ s1 s2)", s.clone())),
     };
 
-    let sc = string_concat_flatten(pool, ss[0].clone());
+    let sc = NormalizedConcat::from_term(pool, &ss[0]);
     let sc_tail = sc.get(1..).unwrap_or_default();
 
-    let t_2_flat = string_concat_flatten(pool, args_t[1].clone());
+    let t_2_flat = NormalizedConcat::from_term(pool, &args_t[1]);
 
-    let v = 1 + overlap(sc_tail, &t_2_flat);
+    let v = 1 + NormalizedConcat::overlap(sc_tail, &t_2_flat);
     let v = pool.add(Term::new_int(v));
-    let oc = build_skolem_prefix(pool, ss[0].clone(), v);
+    let oc = pool.build_str_prefix(&ss[0], &v);
     let oc_len = build_term!(pool, (strlen {oc.clone()}));
 
-    let r = build_skolem_suffix_rem(pool, t_1.clone(), oc_len);
+    let r = pool.build_str_suffix_rem(t_1, &oc_len);
     let expanded = build_term!(pool, (= {t_1.clone()} (strconcat {oc.clone()} {r.clone()})));
 
-    let expanded = expand_string_constants(pool, &expanded);
-    let expected = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &expanded);
+    let expected = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -1198,23 +821,23 @@ pub fn concat_cprop_suffix(RuleArgs { premises, conclusion, pool, .. }: RuleArgs
         _ => return Err(CheckerError::TermOfWrongForm("(str.++ s1 s2)", s.clone())),
     };
 
-    let mut sc = string_concat_flatten(pool, ss[1].clone());
+    let mut sc = NormalizedConcat::from_term(pool, &ss[1]);
     sc.reverse();
     let sc_tail = sc.get(1..).unwrap_or_default();
 
-    let mut t_2_flat = string_concat_flatten(pool, args_t[1].clone());
+    let mut t_2_flat = NormalizedConcat::from_term(pool, &args_t[1]);
     t_2_flat.reverse();
 
-    let v = 1 + overlap(sc_tail, &t_2_flat);
+    let v = 1 + NormalizedConcat::overlap(sc_tail, &t_2_flat);
     let v = pool.add(Term::new_int(v));
-    let oc = build_str_suffix_len(pool, ss[1].clone(), v);
+    let oc = pool.build_str_suffix(&ss[1], &v);
 
     let rhs = build_term!(pool, (- (strlen {t_2.clone()}) (strlen {oc.clone()})));
-    let r = build_skolem_prefix(pool, t_2.clone(), rhs.clone());
+    let r = pool.build_str_prefix(t_2, &rhs);
     let expanded = build_term!(pool, (= {t_2.clone()} (strconcat {r.clone()} {oc.clone()})));
 
-    let expanded = expand_string_constants(pool, &expanded);
-    let expected = expand_string_constants(pool, &conclusion[0]);
+    let expanded = NormalizedConcat::expand_constants(pool, &expanded);
+    let expected = NormalizedConcat::expand_constants(pool, &conclusion[0]);
 
     assert_eq(&expected, &expanded)
 }
@@ -1244,8 +867,8 @@ pub fn string_decompose(
         ) = &conclusion[0]
     )?;
 
-    let w_1 = build_skolem_prefix(pool, t.clone(), n.clone());
-    let w_2 = build_skolem_suffix_rem(pool, t.clone(), n.clone());
+    let w_1 = pool.build_str_prefix(t, n);
+    let w_2 = pool.build_str_suffix_rem(t, n);
     let len_term = if rev { w_2.clone() } else { w_1.clone() };
 
     let expanded = build_term!(
@@ -1348,7 +971,7 @@ pub fn re_kleene_star_unfold_pos(
                     vec![r_1.clone(), r.clone(), r_1.clone()],
                 ));
                 let (k, m) = re_unfold_pos_concat(pool, t.clone(), new_t)?;
-                let concat_args = concat_extract(k.clone());
+                let concat_args = NormalizedConcat::from_term_unsplit(&k);
                 match &concat_args[..] {
                     [k_0, k_1, k_2] => {
                         let eq = build_term!(pool, (= {t.clone()} (strconcat {k_0.clone()} {k_1.clone()} {k_2.clone()})));
@@ -1414,8 +1037,7 @@ pub fn re_concat_unfold_pos(RuleArgs { premises, conclusion, pool, .. }: RuleArg
     let expanded = match r.as_ref() {
         Term::Op(Operator::ReConcat, _) => {
             let (tk, m) = re_unfold_pos_concat(pool, t.clone(), r.clone())?;
-            let concat_args = concat_extract(tk.clone());
-            let new_concat = pool.add(Term::Op(Operator::StrConcat, concat_args));
+            let new_concat = NormalizedConcat::from_term_unsplit(&tk).into_term(pool);
             let teq = build_term!(pool, (= {t.clone()} {new_concat.clone()}));
             if m.is_bool_true() {
                 Ok(teq)
@@ -1438,8 +1060,8 @@ pub fn re_unfold_neg(RuleArgs { premises, conclusion, pool, .. }: RuleArgs) -> R
 
     let int_sort = pool.add_sort(Sort::Int);
     let l = pool.add(Term::new_var("L", int_sort.clone()));
-    let pref = build_skolem_prefix(pool, t.clone(), l.clone());
-    let suff = build_skolem_suffix_rem(pool, t.clone(), l.clone());
+    let pref = pool.build_str_prefix(t, &l);
+    let suff = pool.build_str_suffix_rem(t, &l);
 
     let expanded = match r.as_ref() {
         Term::Op(Operator::ReKleeneClosure, args) => {
@@ -1542,8 +1164,8 @@ pub fn re_unfold_neg_concat_fixed_prefix(
         if let [r_1, r_2 @ ..] = &args[..] {
             let n = Term::new_int(str_fixed_len_re(pool, r_1.clone())?);
             let n = pool.add(n);
-            let pref = build_skolem_prefix(pool, s.clone(), n.clone());
-            let suff = build_skolem_suffix_rem(pool, s.clone(), n.clone());
+            let pref = pool.build_str_prefix(s, &n);
+            let suff = pool.build_str_suffix_rem(s, &n);
             Ok(build_term!(pool,
                 (or
                     (not (strinre {pref.clone()} {r_1.clone()}))
@@ -1583,9 +1205,9 @@ pub fn re_unfold_neg_concat_fixed_suffix(
         if let [r_1, r_2 @ ..] = &args_rev[..] {
             let n = Term::new_int(str_fixed_len_re(pool, r_1.clone())?);
             let n = pool.add(n);
-            let suff = build_skolem_suffix(pool, s.clone(), n.clone());
+            let suff = pool.build_str_suffix(s, &n);
             let size = build_term!(pool, (- (strlen {s.clone()}) {n.clone()}));
-            let pref = build_skolem_prefix(pool, s.clone(), size.clone());
+            let pref = pool.build_str_prefix(s, &size);
             let mut r_2_rev = r_2.to_vec();
             r_2_rev.reverse();
             Ok(build_term!(pool,

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -22,35 +22,24 @@ pub use normalization::NormalizedConcat;
 pub use utils::*;
 
 /// Helper function to properly extract the arguments of the `concat_cprop` rule.
-fn extract_arguments(t: &Rc<Term>) -> Result<Vec<Rc<Term>>, CheckerError> {
-    let args_t = match t.as_ref() {
-        Term::Op(Operator::StrConcat, args) => {
-            if args.len() != 3 {
-                return Err(CheckerError::TermOfWrongForm(
-                    "(str.++ t1 t2 t3)",
-                    t.clone(),
-                ));
-            }
-            args
-        }
-        _ => {
-            return Err(CheckerError::TermOfWrongForm(
-                "(str.++ t1 t2 t3)",
-                t.clone(),
-            ));
-        }
-    };
-    Ok(args_t.clone())
+fn extract_arguments(t: &Rc<Term>) -> Result<&[Rc<Term>], CheckerError> {
+    match t.as_ref() {
+        Term::Op(Operator::StrConcat, args) if args.len() == 3 => Ok(args),
+        _ => Err(CheckerError::TermOfWrongForm(
+            "(str.++ t1 t2 t3)",
+            t.clone(),
+        )),
+    }
 }
 
 /// A function that takes a list of regular expressions and returns the term corresponding to the
 /// application of the concatenation operator to them.
 ///
 /// If the list contains only one regular expression, it returns it directly.
-fn singleton_elim(pool: &mut dyn TermPool, r_list: Vec<Rc<Term>>) -> Rc<Term> {
-    match r_list.len() {
-        1 => r_list[0].clone(),
-        _ => pool.add(Term::Op(Operator::ReConcat, r_list)),
+fn singleton_elim(pool: &mut dyn TermPool, r_list: &[Rc<Term>]) -> Rc<Term> {
+    match r_list {
+        [single] => single.clone(),
+        _ => pool.add(Term::Op(Operator::ReConcat, r_list.to_vec())),
     }
 }
 
@@ -95,24 +84,27 @@ fn re_unfold_pos_concat(
         let mut exists_binding_list: Vec<(String, Rc<Sort>)> = Vec::new();
 
         for j in 0..i {
-            let k_j = pool.add(Term::new_var(format!("k_{j}"), str_sort.clone()));
-            let r_j = pool.add(Term::new_var(format!("R_{j}"), reglan_sort.clone()));
+            let name_k = format!("k_{j}");
+            let name_r = format!("R_{j}");
+            let k_j = pool.add(Term::new_var(name_k.clone(), str_sort.clone()));
+            let r_j = pool.add(Term::new_var(name_r.clone(), reglan_sort.clone()));
             concat_args.push(k_j.clone());
-            and_args.push(build_term!(pool, (strinre {k_j.clone()} {r_j.clone()})));
-            exists_binding_list.push((format!("k_{j}"), str_sort.clone()));
-            exists_binding_list.push((format!("R_{j}"), reglan_sort.clone()));
+            and_args.push(build_term!(pool, (strinre {k_j} {r_j})));
+            exists_binding_list.push((name_k, str_sort.clone()));
+            exists_binding_list.push((name_r, reglan_sort.clone()));
         }
 
         concat_args.push(x.clone());
         concat_args.extend(previous_ks.clone());
         let ks_concat = pool.add(Term::Op(Operator::StrConcat, concat_args));
 
-        let r_i = pool.add(Term::new_var(format!("R_{i}"), reglan_sort.clone()));
-        exists_binding_list.push((format!("R_{i}"), reglan_sort.clone()));
+        let name_r_i = format!("R_{i}");
+        let r_i = pool.add(Term::new_var(name_r_i.clone(), reglan_sort.clone()));
+        exists_binding_list.push((name_r_i, reglan_sort.clone()));
         and_args.push(build_term!(pool, (strinre {x.clone()} {r_i.clone()})));
-        for (j, _) in previous_rs.iter().enumerate() {
+        for (j, prev_r) in previous_rs.iter().enumerate() {
             and_args.push(
-                build_term!(pool, (strinre {previous_ks[j].clone()} {previous_rs[j].clone()})),
+                build_term!(pool, (strinre {previous_ks[j].clone()} {prev_r.clone()})),
             );
             let sum = i + j + 1;
             exists_binding_list.push((format!("R_{sum}"), reglan_sort.clone()));
@@ -212,18 +204,17 @@ fn re_unfold_pos_concat(
 /// It takes an `Rc<Term>` and recursively match over the regular expression operators whose length
 /// can be inferred. It throws an error if the term length cannot be evaluated, i.e., if the length
 /// of the term itself or one of its arguments cannot be inferred.
-fn str_fixed_len_re(pool: &mut dyn TermPool, r: Rc<Term>) -> Result<usize, CheckerError> {
+fn str_fixed_len_re(r: &Rc<Term>) -> Result<usize, CheckerError> {
     fn has_same_length(
-        pool: &mut dyn TermPool,
         args: &[Rc<Term>],
-        r: Rc<Term>,
+        r: &Rc<Term>,
         ignore: Operator,
     ) -> Result<usize, CheckerError> {
         let should_ignore = |term: &Term| term.as_op().is_some_and(|(op, _)| op == ignore);
         let mut iter = args
             .iter()
             .filter(|a| !should_ignore(a))
-            .map(|a| str_fixed_len_re(pool, a.clone()));
+            .map(str_fixed_len_re);
         let Some(first) = iter.next() else {
             return Err(CheckerError::LengthCannotBeEvaluated(r.clone()));
         };
@@ -239,7 +230,7 @@ fn str_fixed_len_re(pool: &mut dyn TermPool, r: Rc<Term>) -> Result<usize, Check
 
     match r.as_ref() {
         Term::Op(Operator::ReConcat, args) => {
-            let mut lengths = args.iter().map(|a| str_fixed_len_re(pool, a.clone()));
+            let mut lengths = args.iter().map(str_fixed_len_re);
             lengths.try_fold(0, |acc, x| Ok(acc + x?))
         }
         Term::Op(Operator::ReAllChar, _) => Ok(1),
@@ -252,10 +243,10 @@ fn str_fixed_len_re(pool: &mut dyn TermPool, r: Rc<Term>) -> Result<usize, Check
             }
         }
         Term::Op(Operator::ReUnion, args) => {
-            has_same_length(pool, args, r.clone(), Operator::ReNone)
+            has_same_length(args, r, Operator::ReNone)
         }
         Term::Op(Operator::ReIntersection, args) => {
-            has_same_length(pool, args, r.clone(), Operator::ReAll)
+            has_same_length(args, r, Operator::ReAll)
         }
         _ => Err(CheckerError::LengthCannotBeEvaluated(r.clone())),
     }
@@ -363,18 +354,17 @@ pub fn concat_conflict(
     let (s, t) = match_term_err!((= s t) = term)?;
     let s_norm = NormalizedConcat::from_term(pool, s);
     let t_norm = NormalizedConcat::from_term(pool, t);
-    let (mut ss, mut ts) = s_norm.strip_prefix_or_suffix(&t_norm, s, t, rev, polyeq_time)?;
-    if rev {
-        ss.reverse();
-        ts.reverse();
-    }
+    let (ss, ts) = s_norm.strip_prefix_or_suffix(&t_norm, s, t, rev, polyeq_time)?;
 
-    if let Some(ss_head) = ss.first() {
+    let ss_head = if rev { ss.last() } else { ss.first() };
+    let ts_head = if rev { ts.last() } else { ts.first() };
+
+    if let Some(ss_head) = ss_head {
         NormalizedConcat::assert_length_one(ss_head)?;
-        if let Some(ts_head) = ts.first() {
+        if let Some(ts_head) = ts_head {
             NormalizedConcat::assert_length_one(ts_head)?;
         }
-    } else if let Some(ts_head) = ts.first() {
+    } else if let Some(ts_head) = ts_head {
         NormalizedConcat::assert_length_one(ts_head)?;
     } else {
         return Err(CheckerError::ExpectedDifferentConstantPrefixes(
@@ -1122,7 +1112,7 @@ pub fn re_unfold_neg(RuleArgs { premises, conclusion, pool, .. }: RuleArgs) -> R
                         (< {l.clone()} 0)
                         (< (strlen {t.clone()}) {l.clone()})
                         (not (strinre {pref.clone()} {r_1.clone()}))
-                        (not (strinre {suff.clone()} {singleton_elim(pool, r_2.to_vec())}))
+                        (not (strinre {suff.clone()} {singleton_elim(pool, r_2)}))
                     )
                 );
                 let quantifier = pool.add(Term::Binder(
@@ -1162,14 +1152,14 @@ pub fn re_unfold_neg_concat_fixed_prefix(
 
     let expanded = if let Term::Op(Operator::ReConcat, args) = r.as_ref() {
         if let [r_1, r_2 @ ..] = &args[..] {
-            let n = Term::new_int(str_fixed_len_re(pool, r_1.clone())?);
+            let n = Term::new_int(str_fixed_len_re(r_1)?);
             let n = pool.add(n);
             let pref = pool.build_str_prefix(s, &n);
             let suff = pool.build_str_suffix_rem(s, &n);
             Ok(build_term!(pool,
                 (or
                     (not (strinre {pref.clone()} {r_1.clone()}))
-                    (not (strinre {suff.clone()} {singleton_elim(pool, r_2.to_vec())}))
+                    (not (strinre {suff.clone()} {singleton_elim(pool, r_2)}))
                 )
             ))
         } else {
@@ -1203,7 +1193,7 @@ pub fn re_unfold_neg_concat_fixed_suffix(
         args_rev.reverse();
 
         if let [r_1, r_2 @ ..] = &args_rev[..] {
-            let n = Term::new_int(str_fixed_len_re(pool, r_1.clone())?);
+            let n = Term::new_int(str_fixed_len_re(r_1)?);
             let n = pool.add(n);
             let suff = pool.build_str_suffix(s, &n);
             let size = build_term!(pool, (- (strlen {s.clone()}) {n.clone()}));
@@ -1213,7 +1203,7 @@ pub fn re_unfold_neg_concat_fixed_suffix(
             Ok(build_term!(pool,
                 (or
                     (not (strinre {suff.clone()} {r_1.clone()}))
-                    (not (strinre {pref.clone()} {singleton_elim(pool, r_2_rev.clone())}))
+                    (not (strinre {pref.clone()} {singleton_elim(pool, &r_2_rev)}))
                 )
             ))
         } else {

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -1,6 +1,9 @@
 pub mod normalization;
 pub mod utils;
 
+pub use normalization::NormalizedConcat;
+pub use utils::*;
+
 use super::{
     RuleArgs, RuleResult, assert_clause_len, assert_eq, assert_num_args, assert_num_premises,
     assert_polyeq, get_premise_term,
@@ -17,9 +20,6 @@ use crate::{
     },
     checker::error::{CheckerError, StringError},
 };
-
-pub use normalization::NormalizedConcat;
-pub use utils::*;
 
 // CPC rule part
 /// Helper function for implementing the `re_kleene_unfold_pos` and `re_concat_unfold_pos` rules.
@@ -1174,8 +1174,16 @@ pub fn re_empty_intersection(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResul
 
     assert_eq(w1, w2)?;
 
-    let a1 = Automaton::determinize(&a1.as_automaton_err()?);
-    let a2 = Automaton::determinize(&a2.as_automaton_err()?);
+    let a1 = a1.as_automaton_err()?;
+    let a2 = a2.as_automaton_err()?;
+
+    // Short circuit
+    if !has_reachable_accepting_state(&a1) || !has_reachable_accepting_state(&a2) {
+        return Ok(());
+    }
+
+    let a1 = Automaton::determinize(&a1);
+    let a2 = Automaton::determinize(&a2);
     let intersection = operations::intersection(a1.clone(), a2.clone())?;
 
     if has_reachable_accepting_state(&intersection) {
@@ -1185,6 +1193,8 @@ pub fn re_empty_intersection(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResul
     Ok(())
 }
 
+// TODO: implementar short circuit aqui também (qualquer autômato que não aceita nenhuma cadeia
+// torna a interseção vazia, basta comparar se a conclusão é vazia também)
 pub fn re_intersection(RuleArgs { premises, conclusion, .. }: RuleArgs) -> RuleResult {
     assert_num_premises(premises, 2..)?;
     assert_clause_len(conclusion, 1)?;

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -21,28 +21,7 @@ use crate::{
 pub use normalization::NormalizedConcat;
 pub use utils::*;
 
-/// Helper function to properly extract the arguments of the `concat_cprop` rule.
-fn extract_arguments(t: &Rc<Term>) -> Result<&[Rc<Term>], CheckerError> {
-    match t.as_ref() {
-        Term::Op(Operator::StrConcat, args) if args.len() == 3 => Ok(args),
-        _ => Err(CheckerError::TermOfWrongForm(
-            "(str.++ t1 t2 t3)",
-            t.clone(),
-        )),
-    }
-}
-
-/// A function that takes a list of regular expressions and returns the term corresponding to the
-/// application of the concatenation operator to them.
-///
-/// If the list contains only one regular expression, it returns it directly.
-fn singleton_elim(pool: &mut dyn TermPool, r_list: &[Rc<Term>]) -> Rc<Term> {
-    match r_list {
-        [single] => single.clone(),
-        _ => pool.add(Term::Op(Operator::ReConcat, r_list.to_vec())),
-    }
-}
-
+// CPC rule part
 /// Helper function for implementing the `re_kleene_unfold_pos` and `re_concat_unfold_pos` rules.
 ///
 /// Internally handles the generation of the Skolem term resulting from `re_unfold_pos_component`,
@@ -103,9 +82,7 @@ fn re_unfold_pos_concat(
         exists_binding_list.push((name_r_i, reglan_sort.clone()));
         and_args.push(build_term!(pool, (strinre {x.clone()} {r_i.clone()})));
         for (j, prev_r) in previous_rs.iter().enumerate() {
-            and_args.push(
-                build_term!(pool, (strinre {previous_ks[j].clone()} {prev_r.clone()})),
-            );
+            and_args.push(build_term!(pool, (strinre {previous_ks[j].clone()} {prev_r.clone()})));
             let sum = i + j + 1;
             exists_binding_list.push((format!("R_{sum}"), reglan_sort.clone()));
         }
@@ -196,60 +173,6 @@ fn re_unfold_pos_concat(
         &mut Vec::new(),
         0,
     )
-}
-
-/// A function to calculate the fixed length of a regular expression `r` (size of strings that
-/// match that RE) if it can be inferred.
-///
-/// It takes an `Rc<Term>` and recursively match over the regular expression operators whose length
-/// can be inferred. It throws an error if the term length cannot be evaluated, i.e., if the length
-/// of the term itself or one of its arguments cannot be inferred.
-fn str_fixed_len_re(r: &Rc<Term>) -> Result<usize, CheckerError> {
-    fn has_same_length(
-        args: &[Rc<Term>],
-        r: &Rc<Term>,
-        ignore: Operator,
-    ) -> Result<usize, CheckerError> {
-        let should_ignore = |term: &Term| term.as_op().is_some_and(|(op, _)| op == ignore);
-        let mut iter = args
-            .iter()
-            .filter(|a| !should_ignore(a))
-            .map(str_fixed_len_re);
-        let Some(first) = iter.next() else {
-            return Err(CheckerError::LengthCannotBeEvaluated(r.clone()));
-        };
-        let first = first?;
-        for size in iter {
-            let size = size?;
-            if size != first {
-                return Err(CheckerError::LengthCannotBeEvaluated(r.clone()));
-            }
-        }
-        Ok(first)
-    }
-
-    match r.as_ref() {
-        Term::Op(Operator::ReConcat, args) => {
-            let mut lengths = args.iter().map(str_fixed_len_re);
-            lengths.try_fold(0, |acc, x| Ok(acc + x?))
-        }
-        Term::Op(Operator::ReAllChar, _) => Ok(1),
-        Term::Op(Operator::ReRange, _) => Ok(1),
-        Term::Op(Operator::StrToRe, args) => {
-            let s_1 = args.first().unwrap();
-            match s_1.as_ref() {
-                Term::Const(Constant::String(s)) => Ok(s.len()),
-                _ => Err(CheckerError::LengthCannotBeEvaluated(r.clone())),
-            }
-        }
-        Term::Op(Operator::ReUnion, args) => {
-            has_same_length(args, r, Operator::ReNone)
-        }
-        Term::Op(Operator::ReIntersection, args) => {
-            has_same_length(args, r, Operator::ReAll)
-        }
-        _ => Err(CheckerError::LengthCannotBeEvaluated(r.clone())),
-    }
 }
 
 // CPC Rules (a little outdated)
@@ -749,7 +672,13 @@ pub fn concat_cprop_prefix(RuleArgs { premises, conclusion, pool, .. }: RuleArgs
     let (t, s) = match_term_err!((= t s) = terms)?;
     let t_1 = match_term_err!((not (= (strlen t_1) 0)) = length)?;
 
-    let args_t = extract_arguments(t)?;
+    let args_t = match t.as_ref() {
+        Term::Op(Operator::StrConcat, args) if args.len() == 3 => Ok(args),
+        _ => Err(CheckerError::TermOfWrongForm(
+            "(str.++ t1 t2 t3)",
+            t.clone(),
+        )),
+    }?;
 
     assert_eq(&args_t[0], t_1)?;
 
@@ -795,7 +724,13 @@ pub fn concat_cprop_suffix(RuleArgs { premises, conclusion, pool, .. }: RuleArgs
     let (t, s) = match_term_err!((= t s) = terms)?;
     let t_2 = match_term_err!((not (= (strlen t_2) 0)) = length)?;
 
-    let args_t = extract_arguments(t)?;
+    let args_t = match t.as_ref() {
+        Term::Op(Operator::StrConcat, args) if args.len() == 3 => Ok(args),
+        _ => Err(CheckerError::TermOfWrongForm(
+            "(str.++ t1 t2 t3)",
+            t.clone(),
+        )),
+    }?;
 
     assert_eq(&args_t[2], t_2)?;
 

--- a/src/checker/rules/strings/mod.rs
+++ b/src/checker/rules/strings/mod.rs
@@ -1178,7 +1178,6 @@ pub fn re_empty_intersection(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResul
     let a1 = a1.as_automaton_err()?;
     let a2 = a2.as_automaton_err()?;
 
-    // Short circuit
     if !has_reachable_accepting_state(&a1) || !has_reachable_accepting_state(&a2) {
         return Ok(());
     }
@@ -1194,40 +1193,62 @@ pub fn re_empty_intersection(RuleArgs { conclusion, .. }: RuleArgs) -> RuleResul
     Ok(())
 }
 
-// TODO: implementar short circuit aqui também (qualquer autômato que não aceita nenhuma cadeia
-// torna a interseção vazia, basta comparar se a conclusão é vazia também)
 pub fn re_intersection(RuleArgs { premises, conclusion, .. }: RuleArgs) -> RuleResult {
     assert_num_premises(premises, 2..)?;
     assert_clause_len(conclusion, 1)?;
 
-    let mut ws: Vec<Rc<Term>> = Vec::new();
-    let mut premise_automatas: Vec<Automaton> = Vec::new();
+    let (w_conc, conc_automaton) = match_term_err!(
+        (strinre w a) = &conclusion[0]
+    )?;
+    let conc_automaton = conc_automaton.as_automaton_err()?;
+
+    let mut has_empty_premise = false;
+    let mut premise_automatas: Vec<Automaton> = Vec::with_capacity(premises.len());
 
     for premise in premises {
         let term = get_premise_term(premise)?;
         let (w, a) = match_term_err!((strinre w a1) = term)?;
-        ws.push(w.clone());
-        premise_automatas.push(Automaton::determinize(&a.as_automaton_err()?));
+        assert_eq(w, w_conc)?;
+
+        let a = a.as_automaton_err()?;
+        if !has_reachable_accepting_state(&a) {
+            has_empty_premise = true;
+        }
+
+        if !has_empty_premise {
+            premise_automatas.push(a);
+        }
     }
 
-    let (w_conc, conc_automaton) = match_term_err!(
-        (strinre w a) = &conclusion[0]
-    )?;
-
-    let mut r = 1;
-    for l in 0..(ws.len() - 1) {
-        assert_eq(&ws[l], &ws[r])?;
-        r += 1;
-    }
-    assert_eq(&ws[r - 1], w_conc)?;
-
-    let mut expected =
-        operations::intersection(premise_automatas[0].clone(), premise_automatas[1].clone())?;
-    for automaton in premise_automatas.iter().skip(2) {
-        expected = operations::intersection(expected, automaton.clone())?;
+    if has_empty_premise {
+        if !has_reachable_accepting_state(&conc_automaton) {
+            return Ok(());
+        } else {
+            let expected = Automaton::empty_automaton();
+            return Err(StringError::ExpectedEquivalentAutomata(
+                expected,
+                Automaton::determinize(&conc_automaton),
+            )
+            .into());
+        }
     }
 
-    let conc_automaton = Automaton::determinize(&conc_automaton.as_automaton_err()?);
+    let mut expected = Automaton::determinize(&premise_automatas[0]);
+    for automaton in &premise_automatas[1..] {
+        let det_a = Automaton::determinize(automaton);
+        expected = operations::intersection(expected, det_a)?;
+        if !has_reachable_accepting_state(&expected) {
+            break;
+        }
+    }
+
+    let conc_is_empty = !has_reachable_accepting_state(&conc_automaton);
+    let expected_is_empty = !has_reachable_accepting_state(&expected);
+    if conc_is_empty && expected_is_empty {
+        return Ok(());
+    }
+
+    let conc_automaton = Automaton::determinize(&conc_automaton);
     if !operations::is_equivalent(expected.clone(), conc_automaton.clone()) {
         return Err(StringError::ExpectedEquivalentAutomata(expected, conc_automaton).into());
     }

--- a/src/checker/rules/strings/normalization.rs
+++ b/src/checker/rules/strings/normalization.rs
@@ -1,0 +1,370 @@
+use crate::{
+    ast::{
+        Constant, MatchCase, Operator, Rc, Term, match_term,
+        pool::TermPool, polyeq,
+    },
+    checker::{
+        error::CheckerError,
+        rules::assert_polyeq_expected,
+    },
+};
+use std::{cmp, ops::{Deref, DerefMut}, time::Duration};
+
+/// A normalized representation of a string concatenation term.
+///
+/// In this flat form:
+/// - All nested `str.++` applications are dissolved.
+/// - String constants are broken down into single-character constant terms.
+/// - Empty string constants `""` are eliminated.
+///
+/// This representation is the canonical form used across string theory checking rules
+/// (CPC calculus) for prefix/suffix extraction, unification, and comparison.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NormalizedConcat(pub Vec<Rc<Term>>);
+
+impl NormalizedConcat {
+    /// Creates a new `NormalizedConcat` wrapping a vector of terms.
+    pub fn new(terms: Vec<Rc<Term>>) -> Self {
+        Self(terms)
+    }
+
+    /// Normalizes a string term into flat form.
+    ///
+    /// Dissolves all `str.++` applications and splits string constants into
+    /// single-character string terms. Empty strings are omitted.
+    pub fn from_term(pool: &mut dyn TermPool, term: &Rc<Term>) -> Self {
+        let mut terms = Vec::new();
+        Self::flatten_term(pool, term, &mut terms);
+        Self(terms)
+    }
+
+    /// Recursively flattens a term into an accumulator vector without allocating
+    /// intermediate vectors.
+    fn flatten_term(pool: &mut dyn TermPool, term: &Rc<Term>, acc: &mut Vec<Rc<Term>>) {
+        if let Term::Const(Constant::String(s)) = term.as_ref() {
+            acc.extend(
+                s.chars()
+                    .map(|c| pool.add(Term::Const(Constant::String(c.to_string())))),
+            );
+        } else if let Some(args) = match_term!((strconcat ...) = term) {
+            for arg in args {
+                Self::flatten_term(pool, arg, acc);
+            }
+        } else {
+            acc.push(term.clone());
+        }
+    }
+
+    /// Extracts subterms by flattening `str.++` applications, but without splitting
+    /// string constants into single characters. Empty strings are omitted.
+    pub fn from_term_unsplit(term: &Rc<Term>) -> Self {
+        let mut terms = Vec::new();
+        Self::extract_unsplit_inner(term, &mut terms);
+        Self(terms)
+    }
+
+    fn extract_unsplit_inner(term: &Rc<Term>, acc: &mut Vec<Rc<Term>>) {
+        if let Term::Const(Constant::String(s)) = term.as_ref() {
+            if !s.is_empty() {
+                acc.push(term.clone());
+            }
+        } else if let Some(args) = match_term!((strconcat ...) = term) {
+            for arg in args {
+                Self::extract_unsplit_inner(arg, acc);
+            }
+        } else {
+            acc.push(term.clone());
+        }
+    }
+
+    /// Converts this normalized sequence back into an AST [`Rc<Term>`].
+    ///
+    /// - If the sequence is empty, returns the empty string term `""`.
+    /// - If it contains exactly one term, returns that term directly.
+    /// - If it contains more than one term, returns an application `(str.++ ...)`.
+    pub fn to_term(&self, pool: &mut dyn TermPool) -> Rc<Term> {
+        match self.0.as_slice() {
+            [] => pool.add(Term::new_string("")),
+            [single] => single.clone(),
+            _ => pool.add(Term::Op(Operator::StrConcat, self.0.clone())),
+        }
+    }
+
+    /// Consumes `self` and converts it into an AST [`Rc<Term>`].
+    pub fn into_term(self, pool: &mut dyn TermPool) -> Rc<Term> {
+        match self.0.len() {
+            0 => pool.add(Term::new_string("")),
+            1 => self.0.into_iter().next().unwrap(),
+            _ => pool.add(Term::Op(Operator::StrConcat, self.0)),
+        }
+    }
+
+    /// Checks if two normalized slices are compatible prefixes of each other.
+    ///
+    /// Pairwise compares elements from head to tail. If either slice is empty,
+    /// or if all overlapping elements match, returns `true`; otherwise `false`.
+    pub fn is_compatible(s: &[Rc<Term>], t: &[Rc<Term>]) -> bool {
+        s.iter().zip(t).all(|(a, b)| a == b)
+    }
+
+    /// Computes the minimal index offset where `s` and `t` become compatible.
+    ///
+    /// If `s` and `t` are already compatible, returns `0`. Otherwise, drops elements from
+    /// the head of `s` until a compatible suffix is found, returning the number of dropped terms.
+    pub fn overlap(s: &[Rc<Term>], t: &[Rc<Term>]) -> usize {
+        let mut current = s;
+        let mut dropped = 0;
+        while current.len() > 1 {
+            if Self::is_compatible(current, t) {
+                return dropped;
+            }
+            current = &current[1..];
+            dropped += 1;
+        }
+        dropped
+    }
+
+    /// Checks if `self` is a prefix of `target`.
+    pub fn assert_is_prefix_of(
+        &self,
+        target: &Self,
+        orig_prefix: &Rc<Term>,
+        orig_target: &Rc<Term>,
+        polyeq_time: &mut Duration,
+    ) -> Result<(), CheckerError> {
+        self.assert_is_prefix_or_suffix_of(target, orig_prefix, orig_target, false, polyeq_time)
+    }
+
+    /// Checks if `self` is a suffix of `target`.
+    pub fn assert_is_suffix_of(
+        &self,
+        target: &Self,
+        orig_suffix: &Rc<Term>,
+        orig_target: &Rc<Term>,
+        polyeq_time: &mut Duration,
+    ) -> Result<(), CheckerError> {
+        self.assert_is_prefix_or_suffix_of(target, orig_suffix, orig_target, true, polyeq_time)
+    }
+
+    /// Checks if `self` is a prefix (rev = `false`) or suffix (rev = `true`) of `target`.
+    ///
+    /// Asserts equality of each overlapping element using `polyeq`. Returns an error
+    /// if `self` is longer than `target` or if any element does not match.
+    pub fn assert_is_prefix_or_suffix_of(
+        &self,
+        target: &Self,
+        orig_prefix: &Rc<Term>,
+        orig_target: &Rc<Term>,
+        rev: bool,
+        polyeq_time: &mut Duration,
+    ) -> Result<(), CheckerError> {
+        if self.len() > target.len() {
+            if rev {
+                return Err(CheckerError::ExpectedToBeSuffix(
+                    orig_prefix.clone(),
+                    orig_target.clone(),
+                ));
+            } else {
+                return Err(CheckerError::ExpectedToBePrefix(
+                    orig_prefix.clone(),
+                    orig_target.clone(),
+                ));
+            }
+        }
+
+        if rev {
+            for (el, t_el) in self.iter().rev().zip(target.iter().rev()) {
+                assert_polyeq_expected(el, t_el.clone(), polyeq_time)?;
+            }
+        } else {
+            for (el, t_el) in self.iter().zip(target.iter()) {
+                assert_polyeq_expected(el, t_el.clone(), polyeq_time)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Removes the longest common prefix (rev = `false`) or suffix (rev = `true`) between
+    /// `self` and `other`.
+    ///
+    /// Returns the remaining tails as a tuple `(remaining_self, remaining_other)`.
+    /// Returns an error if either sequence is empty.
+    pub fn strip_prefix_or_suffix(
+        &self,
+        other: &Self,
+        orig_self: &Rc<Term>,
+        orig_other: &Rc<Term>,
+        rev: bool,
+        polyeq_time: &mut Duration,
+    ) -> Result<(Self, Self), CheckerError> {
+        if self.is_empty() {
+            return Err(CheckerError::TermOfWrongForm("(str.++ ...)", orig_self.clone()));
+        }
+        if other.is_empty() {
+            return Err(CheckerError::TermOfWrongForm("(str.++ ...)", orig_other.clone()));
+        }
+
+        let mut prefix_len = 0;
+        let min_len = cmp::min(self.len(), other.len());
+
+        if rev {
+            while prefix_len < min_len
+                && polyeq(
+                    &self[self.len() - 1 - prefix_len],
+                    &other[other.len() - 1 - prefix_len],
+                    polyeq_time,
+                )
+            {
+                prefix_len += 1;
+            }
+            let s_rem = self[..self.len() - prefix_len].to_vec();
+            let t_rem = other[..other.len() - prefix_len].to_vec();
+            Ok((Self(s_rem), Self(t_rem)))
+        } else {
+            while prefix_len < min_len
+                && polyeq(&self[prefix_len], &other[prefix_len], polyeq_time)
+            {
+                prefix_len += 1;
+            }
+            let s_rem = self.get(prefix_len..).unwrap_or_default().to_vec();
+            let t_rem = other.get(prefix_len..).unwrap_or_default().to_vec();
+            Ok((Self(s_rem), Self(t_rem)))
+        }
+    }
+
+    /// Standardizes String constants and `str.++` applications across an entire AST term.
+    ///
+    /// - Constants of length > 1 are broken into `str.++` of single characters.
+    /// - Nested `str.++` applications are dissolved into a single flat application.
+    pub fn expand_constants(pool: &mut dyn TermPool, term: &Rc<Term>) -> Rc<Term> {
+        match term.as_ref() {
+            Term::Const(Constant::String(s)) => {
+                let args: Vec<Rc<Term>> = s
+                    .chars()
+                    .map(|c| pool.add(Term::Const(Constant::String(c.to_string()))))
+                    .collect();
+                match args.len() {
+                    0 => pool.add(Term::new_string("")),
+                    1 => args[0].clone(),
+                    _ => pool.add(Term::Op(Operator::StrConcat, args)),
+                }
+            }
+            Term::Op(op, args) => match op {
+                Operator::StrConcat => {
+                    let mut new_args = Vec::new();
+                    for arg in args {
+                        Self::flatten_term(pool, arg, &mut new_args);
+                    }
+                    pool.add(Term::Op(*op, new_args))
+                }
+                _ => {
+                    let new_args = args
+                        .iter()
+                        .map(|a| Self::expand_constants(pool, a))
+                        .collect();
+                    pool.add(Term::Op(*op, new_args))
+                }
+            },
+            Term::App(func, args) => {
+                let new_args = args
+                    .iter()
+                    .map(|term| Self::expand_constants(pool, term))
+                    .collect();
+                pool.add(Term::App(func.clone(), new_args))
+            }
+            Term::Let(binding, inner) => {
+                let new_inner = Self::expand_constants(pool, inner);
+                pool.add(Term::Let(binding.clone(), new_inner))
+            }
+            Term::Binder(q, bindings, inner) => {
+                let new_inner = Self::expand_constants(pool, inner);
+                pool.add(Term::Binder(*q, bindings.clone(), new_inner))
+            }
+            Term::ParamOp { op, op_args, args } => {
+                let new_args = args
+                    .iter()
+                    .map(|term| Self::expand_constants(pool, term))
+                    .collect();
+                pool.add(Term::ParamOp {
+                    op: *op,
+                    op_args: op_args.clone(),
+                    args: new_args,
+                })
+            }
+            Term::AsOp(op, sort, args) => {
+                let new_args = args
+                    .iter()
+                    .map(|term| Self::expand_constants(pool, term))
+                    .collect();
+                pool.add(Term::AsOp(*op, sort.clone(), new_args))
+            }
+            Term::Match(t, cases) => {
+                let new_t = Self::expand_constants(pool, t);
+                let new_cases = cases
+                    .iter()
+                    .map(|case| MatchCase {
+                        pattern: case.pattern.clone(),
+                        body: Self::expand_constants(pool, &case.body),
+                    })
+                    .collect();
+                pool.add(Term::Match(new_t, new_cases))
+            }
+            Term::Var(..) | Term::Const(_) => term.clone(),
+        }
+    }
+
+    /// Checks if a term is a string constant of length 1.
+    pub fn assert_length_one(term: &Rc<Term>) -> Result<(), CheckerError> {
+        if let Term::Const(Constant::String(s)) = term.as_ref()
+            && s.len() == 1
+        {
+            return Ok(());
+        }
+        Err(CheckerError::ExpectedStringConstantOfLengthOne(term.clone()))
+    }
+}
+
+// Deref & trait implementations for ergonomic usage
+impl Deref for NormalizedConcat {
+    type Target = [Rc<Term>];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for NormalizedConcat {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for NormalizedConcat {
+    type Item = Rc<Term>;
+    type IntoIter = std::vec::IntoIter<Rc<Term>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a NormalizedConcat {
+    type Item = &'a Rc<Term>;
+    type IntoIter = std::slice::Iter<'a, Rc<Term>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl From<Vec<Rc<Term>>> for NormalizedConcat {
+    fn from(v: Vec<Rc<Term>>) -> Self {
+        Self(v)
+    }
+}
+
+impl From<NormalizedConcat> for Vec<Rc<Term>> {
+    fn from(n: NormalizedConcat) -> Self {
+        n.0
+    }
+}

--- a/src/checker/rules/strings/normalization.rs
+++ b/src/checker/rules/strings/normalization.rs
@@ -1,14 +1,12 @@
 use crate::{
-    ast::{
-        Constant, MatchCase, Operator, Rc, Term, match_term,
-        pool::TermPool, polyeq,
-    },
-    checker::{
-        error::CheckerError,
-        rules::assert_polyeq_expected,
-    },
+    ast::{Constant, MatchCase, Operator, Rc, Term, match_term, polyeq, pool::TermPool},
+    checker::{error::CheckerError, rules::assert_polyeq_expected},
 };
-use std::{cmp, ops::{Deref, DerefMut}, time::Duration};
+use std::{
+    cmp,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
 /// A normalized representation of a string concatenation term.
 ///
@@ -26,6 +24,11 @@ impl NormalizedConcat {
     /// Creates a new `NormalizedConcat` wrapping a vector of terms.
     pub fn new(terms: Vec<Rc<Term>>) -> Self {
         Self(terms)
+    }
+
+    /// Returns a slice of the underlying terms.
+    pub fn as_slice(&self) -> &[Rc<Term>] {
+        &self.0
     }
 
     /// Normalizes a string term into flat form.
@@ -153,7 +156,7 @@ impl NormalizedConcat {
     pub fn assert_is_prefix_or_suffix_of(
         &self,
         target: &Self,
-        orig_prefix: &Rc<Term>,
+        orig_substr: &Rc<Term>,
         orig_target: &Rc<Term>,
         rev: bool,
         polyeq_time: &mut Duration,
@@ -161,12 +164,12 @@ impl NormalizedConcat {
         if self.len() > target.len() {
             if rev {
                 return Err(CheckerError::ExpectedToBeSuffix(
-                    orig_prefix.clone(),
+                    orig_substr.clone(),
                     orig_target.clone(),
                 ));
             } else {
                 return Err(CheckerError::ExpectedToBePrefix(
-                    orig_prefix.clone(),
+                    orig_substr.clone(),
                     orig_target.clone(),
                 ));
             }
@@ -181,6 +184,7 @@ impl NormalizedConcat {
                 assert_polyeq_expected(el, t_el.clone(), polyeq_time)?;
             }
         }
+
         Ok(())
     }
 
@@ -198,10 +202,16 @@ impl NormalizedConcat {
         polyeq_time: &mut Duration,
     ) -> Result<(Self, Self), CheckerError> {
         if self.is_empty() {
-            return Err(CheckerError::TermOfWrongForm("(str.++ ...)", orig_self.clone()));
+            return Err(CheckerError::TermOfWrongForm(
+                "(str.++ ...)",
+                orig_self.clone(),
+            ));
         }
         if other.is_empty() {
-            return Err(CheckerError::TermOfWrongForm("(str.++ ...)", orig_other.clone()));
+            return Err(CheckerError::TermOfWrongForm(
+                "(str.++ ...)",
+                orig_other.clone(),
+            ));
         }
 
         let mut prefix_len = 0;
@@ -221,8 +231,7 @@ impl NormalizedConcat {
             let t_rem = other[..other.len() - prefix_len].to_vec();
             Ok((Self(s_rem), Self(t_rem)))
         } else {
-            while prefix_len < min_len
-                && polyeq(&self[prefix_len], &other[prefix_len], polyeq_time)
+            while prefix_len < min_len && polyeq(&self[prefix_len], &other[prefix_len], polyeq_time)
             {
                 prefix_len += 1;
             }
@@ -320,7 +329,9 @@ impl NormalizedConcat {
         {
             return Ok(());
         }
-        Err(CheckerError::ExpectedStringConstantOfLengthOne(term.clone()))
+        Err(CheckerError::ExpectedStringConstantOfLengthOne(
+            term.clone(),
+        ))
     }
 }
 
@@ -366,5 +377,244 @@ impl From<Vec<Rc<Term>>> for NormalizedConcat {
 impl From<NormalizedConcat> for Vec<Rc<Term>> {
     fn from(n: NormalizedConcat) -> Self {
         n.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::pool::PrimitivePool;
+    use std::slice;
+    use std::time::Duration;
+
+    #[test]
+    fn test_from_term_flatten_constants() {
+        let mut pool = PrimitivePool::new();
+        let term = pool.add(Term::new_string("abc"));
+        let norm = NormalizedConcat::from_term(&mut pool, &term);
+
+        assert_eq!(norm.len(), 3);
+        assert_eq!(norm[0], pool.add(Term::new_string("a")));
+        assert_eq!(norm[1], pool.add(Term::new_string("b")));
+        assert_eq!(norm[2], pool.add(Term::new_string("c")));
+    }
+
+    #[test]
+    fn test_from_term_omits_empty_strings() {
+        let mut pool = PrimitivePool::new();
+        let empty = pool.add(Term::new_string(""));
+        let norm = NormalizedConcat::from_term(&mut pool, &empty);
+        assert!(norm.is_empty());
+
+        let a = pool.add(Term::new_string("a"));
+        let concat_with_empty = pool.add(Term::Op(Operator::StrConcat, vec![empty, a.clone()]));
+        let norm2 = NormalizedConcat::from_term(&mut pool, &concat_with_empty);
+        assert_eq!(norm2.as_slice(), &[a]);
+    }
+
+    #[test]
+    fn test_from_term_nested_concat() {
+        let mut pool = PrimitivePool::new();
+        let str_sort = pool.add_sort(crate::ast::Sort::String);
+        let x = pool.add(Term::new_var("x", str_sort));
+        let ab = pool.add(Term::new_string("ab"));
+        let c = pool.add(Term::new_string("c"));
+
+        let inner = pool.add(Term::Op(Operator::StrConcat, vec![x.clone(), ab]));
+        let outer = pool.add(Term::Op(Operator::StrConcat, vec![inner, c]));
+
+        let norm = NormalizedConcat::from_term(&mut pool, &outer);
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+        let c = pool.add(Term::new_string("c"));
+
+        assert_eq!(norm.as_slice(), &[x, a, b, c]);
+    }
+
+    #[test]
+    fn test_from_term_unsplit() {
+        let mut pool = PrimitivePool::new();
+        let hello = pool.add(Term::new_string("hello"));
+        let world = pool.add(Term::new_string("world"));
+        let empty = pool.add(Term::new_string(""));
+
+        let concat = pool.add(Term::Op(
+            Operator::StrConcat,
+            vec![hello.clone(), empty, world.clone()],
+        ));
+        let norm = NormalizedConcat::from_term_unsplit(&concat);
+
+        assert_eq!(norm.as_slice(), &[hello, world]);
+    }
+
+    #[test]
+    fn test_to_term_and_into_term() {
+        let mut pool = PrimitivePool::new();
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+
+        // Empty
+        let empty_norm = NormalizedConcat::new(vec![]);
+        assert_eq!(
+            empty_norm.to_term(&mut pool),
+            pool.add(Term::new_string(""))
+        );
+
+        // Single
+        let single_norm = NormalizedConcat::new(vec![a.clone()]);
+        assert_eq!(single_norm.to_term(&mut pool), a);
+
+        // Multiple
+        let multi_norm = NormalizedConcat::new(vec![a.clone(), b.clone()]);
+        let expected = pool.add(Term::Op(Operator::StrConcat, vec![a, b]));
+        assert_eq!(multi_norm.into_term(&mut pool), expected);
+    }
+
+    #[test]
+    fn test_is_compatible() {
+        let mut pool = PrimitivePool::new();
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+        let c = pool.add(Term::new_string("c"));
+
+        // Both empty or one empty
+        assert!(NormalizedConcat::is_compatible(&[], &[]));
+        assert!(NormalizedConcat::is_compatible(slice::from_ref(&a), &[]));
+        assert!(NormalizedConcat::is_compatible(&[], slice::from_ref(&a)));
+
+        // Matching prefix
+        assert!(NormalizedConcat::is_compatible(
+            &[a.clone(), b.clone()],
+            &[a.clone(), b.clone(), c.clone()]
+        ));
+
+        // Mismatched
+        assert!(!NormalizedConcat::is_compatible(&[a.clone(), b], &[a, c]));
+    }
+
+    #[test]
+    fn test_overlap() {
+        let mut pool = PrimitivePool::new();
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+        let c = pool.add(Term::new_string("c"));
+
+        // Already compatible (offset 0)
+        let s1 = vec![a.clone(), b.clone()];
+        let t1 = vec![a.clone(), b.clone(), c.clone()];
+        assert_eq!(NormalizedConcat::overlap(&s1, &t1), 0);
+
+        // Compatible after dropping 1 element
+        let s2 = vec![c.clone(), a.clone(), b.clone()];
+        let t2 = vec![a.clone(), b.clone()];
+        assert_eq!(NormalizedConcat::overlap(&s2, &t2), 1);
+
+        // Incompatible until last element
+        let s3 = vec![a.clone(), b.clone(), c.clone()];
+        let t3 = vec![pool.add(Term::new_string("d"))];
+        assert_eq!(NormalizedConcat::overlap(&s3, &t3), 2);
+    }
+
+    #[test]
+    fn test_strip_prefix_or_suffix() {
+        let mut pool = PrimitivePool::new();
+        let mut polyeq_time = Duration::ZERO;
+
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+        let c = pool.add(Term::new_string("c"));
+        let d = pool.add(Term::new_string("d"));
+
+        // Prefix stripping (rev = false)
+        let s = NormalizedConcat::new(vec![a.clone(), b.clone(), c.clone()]);
+        let t = NormalizedConcat::new(vec![a.clone(), b.clone(), d.clone()]);
+        let (s_rem, t_rem) = s
+            .strip_prefix_or_suffix(&t, &a, &a, false, &mut polyeq_time)
+            .unwrap();
+        assert_eq!(s_rem.as_slice(), slice::from_ref(&c));
+        assert_eq!(t_rem.as_slice(), slice::from_ref(&d));
+
+        // Suffix stripping (rev = true)
+        let s_suff = NormalizedConcat::new(vec![c.clone(), a.clone(), b.clone()]);
+        let t_suff = NormalizedConcat::new(vec![d.clone(), a.clone(), b.clone()]);
+        let (s_rem2, t_rem2) = s_suff
+            .strip_prefix_or_suffix(&t_suff, &a, &a, true, &mut polyeq_time)
+            .unwrap();
+        assert_eq!(s_rem2.as_slice(), &[c]);
+        assert_eq!(t_rem2.as_slice(), &[d]);
+
+        // Empty input returns error
+        let empty = NormalizedConcat::new(vec![]);
+        assert!(
+            s.strip_prefix_or_suffix(&empty, &a, &a, false, &mut polyeq_time)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_assert_is_prefix_and_suffix() {
+        let mut pool = PrimitivePool::new();
+        let mut polyeq_time = Duration::ZERO;
+
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+        let c = pool.add(Term::new_string("c"));
+
+        let target = NormalizedConcat::new(vec![a.clone(), b.clone(), c.clone()]);
+        let prefix = NormalizedConcat::new(vec![a.clone(), b.clone()]);
+        let suffix = NormalizedConcat::new(vec![b.clone(), c.clone()]);
+
+        assert!(
+            prefix
+                .assert_is_prefix_of(&target, &a, &a, &mut polyeq_time)
+                .is_ok()
+        );
+        assert!(
+            suffix
+                .assert_is_suffix_of(&target, &a, &a, &mut polyeq_time)
+                .is_ok()
+        );
+
+        // Prefix too long
+        let too_long = NormalizedConcat::new(vec![a.clone(), b.clone(), c.clone(), a.clone()]);
+        assert!(
+            too_long
+                .assert_is_prefix_of(&target, &a, &a, &mut polyeq_time)
+                .is_err()
+        );
+
+        // Mismatched prefix
+        let mismatch = NormalizedConcat::new(vec![b.clone(), a.clone()]);
+        assert!(
+            mismatch
+                .assert_is_prefix_of(&target, &a, &a, &mut polyeq_time)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_assert_length_one() {
+        let mut pool = PrimitivePool::new();
+        let one = pool.add(Term::new_string("x"));
+        let two = pool.add(Term::new_string("xy"));
+        let empty = pool.add(Term::new_string(""));
+        let int_term = pool.add(Term::new_int(1));
+
+        assert!(NormalizedConcat::assert_length_one(&one).is_ok());
+        assert!(NormalizedConcat::assert_length_one(&two).is_err());
+        assert!(NormalizedConcat::assert_length_one(&empty).is_err());
+        assert!(NormalizedConcat::assert_length_one(&int_term).is_err());
+    }
+
+    #[test]
+    fn test_expand_constants() {
+        let mut pool = PrimitivePool::new();
+        let ab = pool.add(Term::new_string("ab"));
+        let expanded = NormalizedConcat::expand_constants(&mut pool, &ab);
+
+        let a = pool.add(Term::new_string("a"));
+        let b = pool.add(Term::new_string("b"));
+        let expected = pool.add(Term::Op(Operator::StrConcat, vec![a, b]));
+        assert_eq!(expanded, expected);
     }
 }

--- a/src/checker/rules/strings/utils.rs
+++ b/src/checker/rules/strings/utils.rs
@@ -5,11 +5,12 @@ use std::sync::Arc;
 use indexmap::IndexMap;
 
 use crate::{
-    ast::{Operator, Rc, Term, build_term, pool::TermPool},
+    ast::{Constant, Operator, Rc, Term, build_term, pool::TermPool},
     automata::Automaton,
     checker::error::{CheckerError, StringError},
 };
 
+// CPC utils
 /// Orientation for string operations that distinguish between prefix and suffix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Orientation {
@@ -95,6 +96,67 @@ impl<T: TermPool + ?Sized> StringTermBuilder for T {
             }
         };
         build_term!(self, (ite (>= (strlen {t.clone()}) (strlen {s.clone()})) {true_branch} {false_branch}))
+    }
+}
+
+/// A function to calculate the fixed length of a regular expression `r` (size of strings that
+/// match that RE) if it can be inferred.
+///
+/// It takes an `Rc<Term>` and recursively match over the regular expression operators whose length
+/// can be inferred. It throws an error if the term length cannot be evaluated, i.e., if the length
+/// of the term itself or one of its arguments cannot be inferred.
+pub fn str_fixed_len_re(r: &Rc<Term>) -> Result<usize, CheckerError> {
+    fn has_same_length(
+        args: &[Rc<Term>],
+        r: &Rc<Term>,
+        ignore: Operator,
+    ) -> Result<usize, CheckerError> {
+        let should_ignore = |term: &Term| term.as_op().is_some_and(|(op, _)| op == ignore);
+        let mut iter = args
+            .iter()
+            .filter(|a| !should_ignore(a))
+            .map(str_fixed_len_re);
+        let Some(first) = iter.next() else {
+            return Err(CheckerError::LengthCannotBeEvaluated(r.clone()));
+        };
+        let first = first?;
+        for size in iter {
+            let size = size?;
+            if size != first {
+                return Err(CheckerError::LengthCannotBeEvaluated(r.clone()));
+            }
+        }
+        Ok(first)
+    }
+
+    match r.as_ref() {
+        Term::Op(Operator::ReConcat, args) => {
+            let mut lengths = args.iter().map(str_fixed_len_re);
+            lengths.try_fold(0, |acc, x| Ok(acc + x?))
+        }
+        Term::Op(Operator::ReAllChar, _) => Ok(1),
+        Term::Op(Operator::ReRange, _) => Ok(1),
+        Term::Op(Operator::StrToRe, args) => {
+            let s_1 = args.first().unwrap();
+            match s_1.as_ref() {
+                Term::Const(Constant::String(s)) => Ok(s.len()),
+                _ => Err(CheckerError::LengthCannotBeEvaluated(r.clone())),
+            }
+        }
+        Term::Op(Operator::ReUnion, args) => has_same_length(args, r, Operator::ReNone),
+        Term::Op(Operator::ReIntersection, args) => has_same_length(args, r, Operator::ReAll),
+        _ => Err(CheckerError::LengthCannotBeEvaluated(r.clone())),
+    }
+}
+
+/// A function that takes a list of regular expressions and returns the term corresponding to the
+/// application of the concatenation operator to them.
+///
+/// If the list contains only one regular expression, it returns it directly.
+pub fn singleton_elim(pool: &mut dyn TermPool, r_list: &[Rc<Term>]) -> Rc<Term> {
+    match r_list {
+        [single] => single.clone(),
+        _ => pool.add(Term::Op(Operator::ReConcat, r_list.to_vec())),
     }
 }
 

--- a/src/checker/rules/strings/utils.rs
+++ b/src/checker/rules/strings/utils.rs
@@ -1,0 +1,152 @@
+use super::assert_eq;
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+
+use crate::{
+    ast::{Operator, Rc, Term, build_term, pool::TermPool},
+    automata::Automaton,
+    checker::error::{CheckerError, StringError},
+};
+
+/// Orientation for string operations that distinguish between prefix and suffix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Orientation {
+    Prefix,
+    Suffix,
+}
+
+/// Extension trait for [`TermPool`] providing helper methods to build common
+/// string theory terms (prefixes, suffixes, remainder suffixes, and Skolem unification splits).
+pub trait StringTermBuilder {
+    /// Builds a term representing the prefix of `u` of length `n`:
+    /// `(str.substr u 0 n)`
+    fn build_str_prefix(&mut self, u: &Rc<Term>, n: &Rc<Term>) -> Rc<Term>;
+
+    /// Builds a term representing the remainder suffix of `u` after dropping `n` characters:
+    /// `(str.substr u n (- (str.len u) n))`
+    fn build_str_suffix_rem(&mut self, u: &Rc<Term>, n: &Rc<Term>) -> Rc<Term>;
+
+    /// Builds a term representing the suffix of `u` of length `n`:
+    /// `(str.substr u (- (str.len u) n) n)`
+    fn build_str_suffix(&mut self, u: &Rc<Term>, n: &Rc<Term>) -> Rc<Term>;
+
+    /// Builds a Skolem term for unification splitting between `t` and `s`.
+    ///
+    /// - If `orientation` is `Orientation::Prefix`:
+    ///   If `(str.len t) >= (str.len s)`, extracts remainder suffix of `t` after length `(str.len s)`;
+    ///   otherwise, extracts remainder suffix of `s` after length `(str.len t)`.
+    /// - If `orientation` is `Orientation::Suffix`:
+    ///   If `(str.len t) >= (str.len s)`, extracts prefix of `t` of length `(- (str.len t) (str.len s))`;
+    ///   otherwise, extracts prefix of `s` of length `(- (str.len s) (str.len t))`.
+    fn build_str_unify_split(
+        &mut self,
+        t: &Rc<Term>,
+        s: &Rc<Term>,
+        orientation: Orientation,
+    ) -> Rc<Term>;
+
+    /// Builds a prefix unification splitting term between `t` and `s`.
+    fn build_str_unify_split_prefix(&mut self, t: &Rc<Term>, s: &Rc<Term>) -> Rc<Term> {
+        self.build_str_unify_split(t, s, Orientation::Prefix)
+    }
+
+    /// Builds a suffix unification splitting term between `t` and `s`.
+    fn build_str_unify_split_suffix(&mut self, t: &Rc<Term>, s: &Rc<Term>) -> Rc<Term> {
+        self.build_str_unify_split(t, s, Orientation::Suffix)
+    }
+}
+
+impl<T: TermPool + ?Sized> StringTermBuilder for T {
+    fn build_str_prefix(&mut self, u: &Rc<Term>, n: &Rc<Term>) -> Rc<Term> {
+        build_term!(self, (strsubstr {u.clone()} 0 {n.clone()}))
+    }
+
+    fn build_str_suffix_rem(&mut self, u: &Rc<Term>, n: &Rc<Term>) -> Rc<Term> {
+        build_term!(self, (strsubstr {u.clone()} {n.clone()} (- (strlen {u.clone()}) {n.clone()})))
+    }
+
+    fn build_str_suffix(&mut self, u: &Rc<Term>, n: &Rc<Term>) -> Rc<Term> {
+        build_term!(self, (strsubstr {u.clone()} (- (strlen {u.clone()}) {n.clone()}) {n.clone()}))
+    }
+
+    fn build_str_unify_split(
+        &mut self,
+        t: &Rc<Term>,
+        s: &Rc<Term>,
+        orientation: Orientation,
+    ) -> Rc<Term> {
+        let t_len = self.add(Term::Op(Operator::StrLen, vec![t.clone()]));
+        let s_len = self.add(Term::Op(Operator::StrLen, vec![s.clone()]));
+
+        let (true_branch, false_branch) = match orientation {
+            Orientation::Prefix => (
+                self.build_str_suffix_rem(t, &s_len),
+                self.build_str_suffix_rem(s, &t_len),
+            ),
+            Orientation::Suffix => {
+                let n_t = build_term!(self, (- {t_len.clone()} {s_len.clone()}));
+                let n_s = build_term!(self, (- {s_len.clone()} {t_len.clone()}));
+                (
+                    self.build_str_prefix(t, &n_t),
+                    self.build_str_prefix(s, &n_s),
+                )
+            }
+        };
+        build_term!(self, (ite (>= (strlen {t.clone()}) (strlen {s.clone()})) {true_branch} {false_branch}))
+    }
+}
+
+// RCP utils
+/// Builds the automaton for a regex term, reusing the per-proof cache: proofs
+/// commonly apply many regex-eval steps to the same (hash-consed) regex.
+pub fn cached_automaton(
+    pool: &mut dyn TermPool,
+    cache: &mut IndexMap<Rc<Term>, Arc<Automaton>>,
+    regex: &Rc<Term>,
+) -> Result<Arc<Automaton>, CheckerError> {
+    if let Some(a) = cache.get(regex) {
+        return Ok(a.clone());
+    }
+    let a = Arc::new(Automaton::create_from_regex_operators(pool, regex)?);
+    cache.insert(regex.clone(), a.clone());
+    Ok(a)
+}
+
+/// Constructs an automaton for a string term `t` by combining the automata from the rule premises.
+///
+/// For a concatenation term `(str.++ s_0 ... s_n)`, it verifies that each component `s_i` matches
+/// its corresponding premise `(str.in_re s_i A_i)` and builds the concatenated regular expression
+/// automaton `(re.++ A_0 ... A_n)`.
+pub fn make_automaton_from_string(
+    pool: &mut dyn TermPool,
+    t: &Rc<Term>,
+    premise_automatas: Vec<(Rc<Term>, Rc<Term>)>,
+) -> Result<Automaton, CheckerError> {
+    match t.as_ref() {
+        Term::Op(Operator::StrConcat, ss) => {
+            if ss.len() != premise_automatas.len() {
+                return Err(StringError::ConcatTermsNumberDiffersFromPremiseTermsNumber(
+                    ss.len(),
+                    premise_automatas.len(),
+                )
+                .into());
+            }
+
+            let mut components: Vec<Rc<Term>> = Vec::new();
+            for (index, w) in ss.iter().enumerate() {
+                let premise_a = premise_automatas[index].clone();
+                assert_eq(w, &premise_a.0)?;
+                components.push(premise_a.1.clone());
+            }
+
+            let regex_a = pool.add(Term::Op(Operator::ReConcat, components));
+            Ok(Automaton::create_from_regex_operators(pool, &regex_a)?)
+        }
+        // TODO: add other forwadable functions
+        // Term::Op(Operator::Replace, _) => {}
+        // Term::Op(Operator::ReplaceAll, _) => {}
+        _ => Err(StringError::NotBackwardableOperator(t.clone()).into()),
+    }
+}

--- a/src/checker/rules/strings/utils.rs
+++ b/src/checker/rules/strings/utils.rs
@@ -150,3 +150,125 @@ pub fn make_automaton_from_string(
         _ => Err(StringError::NotBackwardableOperator(t.clone()).into()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{match_term, pool::PrimitivePool};
+
+    #[test]
+    fn test_build_str_prefix() {
+        let mut pool = PrimitivePool::new();
+        let str_sort = pool.add_sort(crate::ast::Sort::String);
+        let int_sort = pool.add_sort(crate::ast::Sort::Int);
+        let u = pool.add(Term::new_var("u", str_sort));
+        let n = pool.add(Term::new_var("n", int_sort));
+
+        let term = pool.build_str_prefix(&u, &n);
+        let expected = build_term!(pool, (strsubstr {u} 0 {n}));
+        assert_eq!(term, expected);
+    }
+
+    #[test]
+    fn test_build_str_suffix() {
+        let mut pool = PrimitivePool::new();
+        let str_sort = pool.add_sort(crate::ast::Sort::String);
+        let int_sort = pool.add_sort(crate::ast::Sort::Int);
+        let u = pool.add(Term::new_var("u", str_sort));
+        let n = pool.add(Term::new_var("n", int_sort));
+
+        let term = pool.build_str_suffix(&u, &n);
+        let expected = build_term!(pool, (strsubstr {u.clone()} (- (strlen {u}) {n.clone()}) {n}));
+        assert_eq!(term, expected);
+    }
+
+    #[test]
+    fn test_build_str_suffix_rem() {
+        let mut pool = PrimitivePool::new();
+        let str_sort = pool.add_sort(crate::ast::Sort::String);
+        let int_sort = pool.add_sort(crate::ast::Sort::Int);
+        let u = pool.add(Term::new_var("u", str_sort));
+        let n = pool.add(Term::new_var("n", int_sort));
+
+        let term = pool.build_str_suffix_rem(&u, &n);
+        let expected = build_term!(pool, (strsubstr {u.clone()} {n.clone()} (- (strlen {u}) {n})));
+        assert_eq!(term, expected);
+    }
+
+    #[test]
+    fn test_build_str_unify_split_prefix_and_suffix() {
+        let mut pool = PrimitivePool::new();
+        let str_sort = pool.add_sort(crate::ast::Sort::String);
+        let t = pool.add(Term::new_var("t", str_sort.clone()));
+        let s = pool.add(Term::new_var("s", str_sort));
+
+        let pref_term = pool.build_str_unify_split(&t, &s, Orientation::Prefix);
+        let suff_term = pool.build_str_unify_split(&t, &s, Orientation::Suffix);
+
+        assert!(
+            match_term!(
+                (ite (>= (strlen ...) (strlen ...)) (strsubstr ...) (strsubstr ...)) = &pref_term
+            )
+            .is_some()
+        );
+        assert!(
+            match_term!(
+                (ite (>= (strlen ...) (strlen ...)) (strsubstr ...) (strsubstr ...)) = &suff_term
+            )
+            .is_some()
+        );
+        assert_ne!(pref_term, suff_term);
+    }
+
+    #[test]
+    fn test_cached_automaton() {
+        let mut pool = PrimitivePool::new();
+        let mut cache = IndexMap::new();
+
+        let a = pool.add(Term::new_string("a"));
+        let re_a = pool.add(Term::Op(Operator::StrToRe, vec![a]));
+
+        let auto1 = cached_automaton(&mut pool, &mut cache, &re_a).unwrap();
+        let auto2 = cached_automaton(&mut pool, &mut cache, &re_a).unwrap();
+
+        assert!(Arc::ptr_eq(&auto1, &auto2));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_make_automaton_from_string_success() {
+        let mut pool = PrimitivePool::new();
+        let s1 = pool.add(Term::new_string("a"));
+        let s2 = pool.add(Term::new_string("b"));
+        let concat = pool.add(Term::Op(Operator::StrConcat, vec![s1.clone(), s2.clone()]));
+
+        let re1 = pool.add(Term::Op(Operator::StrToRe, vec![s1.clone()]));
+        let re2 = pool.add(Term::Op(Operator::StrToRe, vec![s2.clone()]));
+
+        let premises = vec![(s1, re1), (s2, re2)];
+        let automaton = make_automaton_from_string(&mut pool, &concat, premises);
+        assert!(automaton.is_ok());
+    }
+
+    #[test]
+    fn test_make_automaton_from_string_mismatch() {
+        let mut pool = PrimitivePool::new();
+        let s1 = pool.add(Term::new_string("a"));
+        let s2 = pool.add(Term::new_string("b"));
+        let concat = pool.add(Term::Op(Operator::StrConcat, vec![s1.clone(), s2.clone()]));
+
+        let re1 = pool.add(Term::Op(Operator::StrToRe, vec![s1.clone()]));
+        let premises = vec![(s1, re1)]; // Wrong number of premises
+
+        let result = make_automaton_from_string(&mut pool, &concat, premises);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_make_automaton_from_string_invalid_operator() {
+        let mut pool = PrimitivePool::new();
+        let s = pool.add(Term::new_string("a"));
+        let result = make_automaton_from_string(&mut pool, &s, vec![]);
+        assert!(result.is_err());
+    }
+}

--- a/src/checker/shared.rs
+++ b/src/checker/shared.rs
@@ -392,11 +392,6 @@ pub fn get_rule(
         "cp_literal" => cutting_planes::cp_literal,
         "cp_normalize" => cutting_planes::cp_normalize,
 
-        // Common String rules
-        "str_in_re_eval" => strings::str_in_re_eval,
-        "str_replace_re_eval" => strings::str_replace_re_eval,
-        "str_replace_re_all_eval" => strings::str_replace_re_all_eval,
-
         // CPC String rules
         "string_decompose" => strings::string_decompose,
         "string_length_pos" => strings::string_length_pos,
@@ -415,6 +410,12 @@ pub fn get_rule(
         "re_forward_prop" => strings::re_forward_prop,
         "concat_bwd_propagation" => strings::concat_bwd_propagation,
         "concat_aut_bwd_propagation" => strings::concat_aut_bwd_propagation,
+
+        // RE eval rules
+        "str_indexof_re_eval" => strings::str_indexof_re_eval,
+        "str_replace_re_eval" => strings::str_replace_re_eval,
+        "str_replace_re_all_eval" => strings::str_replace_re_all_eval,
+        "str_in_re_eval" => strings::str_in_re_eval,
 
         // Drup format rules
         "drup" => |x| crate::checker::rules::drup::drup(false, x),

--- a/src/checker/shared.rs
+++ b/src/checker/shared.rs
@@ -392,16 +392,30 @@ pub fn get_rule(
         "cp_literal" => cutting_planes::cp_literal,
         "cp_normalize" => cutting_planes::cp_normalize,
 
+        // Common String rules
+        "str_in_re_eval" => strings::str_in_re_eval,
+        "str_replace_re_eval" => strings::str_replace_re_eval,
+        "str_replace_re_all_eval" => strings::str_replace_re_all_eval,
+
+        // CPC String rules
         "string_decompose" => strings::string_decompose,
         "string_length_pos" => strings::string_length_pos,
         "string_length_non_empty" => strings::string_length_non_empty,
-
         "re_inter" => strings::re_inter,
         "re_kleene_star_unfold_pos" => strings::re_kleene_star_unfold_pos,
         "re_concat_unfold_pos" => strings::re_concat_unfold_pos,
         "re_unfold_neg" => strings::re_unfold_neg,
         "re_unfold_neg_concat_fixed_prefix" => strings::re_unfold_neg_concat_fixed_prefix,
         "re_unfold_neg_concat_fixed_suffix" => strings::re_unfold_neg_concat_fixed_suffix,
+
+        // RCP String rules
+        "re_convert" => strings::re_convert,
+        "re_empty_intersection" => strings::re_empty_intersection,
+        "re_intersection" => strings::re_intersection,
+        "re_forward_prop" => strings::re_forward_prop,
+        "concat_bwd_propagation" => strings::concat_bwd_propagation,
+        "concat_aut_bwd_propagation" => strings::concat_aut_bwd_propagation,
+
         // Drup format rules
         "drup" => |x| crate::checker::rules::drup::drup(false, x),
         // Drat format rules

--- a/tests/rules/strings.rs
+++ b/tests/rules/strings.rs
@@ -1705,3 +1705,19 @@ fn str_in_re_eval() {
         }
     }
 }
+
+#[test]
+fn str_indexof_re_eval() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}

--- a/tests/rules/strings.rs
+++ b/tests/rules/strings.rs
@@ -1560,3 +1560,148 @@ fn re_concat_unfold_pos() {
         }
     }
 }
+
+// TODO: add test cases for all rules
+#[test]
+fn re_convert() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn re_empty_intersection() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn re_intersection() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn re_forward_prop() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn concat_bwd_propagation() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn concat_aut_bwd_propagation() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn str_replace_re_eval() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn str_replace_re_all_eval() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}
+
+#[test]
+fn str_in_re_eval() {
+    test_cases! {
+        definitions = "
+            (declare-fun a () String)
+            (declare-fun b () String)
+        ",
+        "Simple working examples" {
+            r#"(assume h1 (>= (str.len "ab") 2))
+               (define-fun w_1 () String (str.substr "ab" 0 2))
+               (define-fun w_2 () String (str.substr "ab" 2 (- (str.len "ab") 2)))
+               (step t1 (cl (and (= "ab" (str.++ w_1 w_2)) (= (str.len w_1) 2))) :rule string_decompose :premises (h1) :args (false))"#: true,
+        }
+    }
+}


### PR DESCRIPTION
This PR builds on the finite automata infrastructure introduced in [PR #137](https://github.com/ufmg-smite/carcara/pull/137) and adds the verification procedures for the Regular Constraint Propagation (RCP) calculus in Alethe proofs.

The implementation is motivated by the ongoing work on extending OSTRICH to generate proofs in the Alethe format. The theoretical foundations for the decision procedures and constraint propagation over regular languages follow the approach presented in

> ["*The Power of Regular Constraint Propagation*"](https://dl.acm.org/doi/10.1145/3763165)
> (Matthew Hague, Artur Jeź, Anthony Widjaja Lin, Oliver Markgraf, Phlipp Rümmer, 2025).

The main additions in this PR are:
* **Proof Rule Verification:** Added verification procedures for the regular constraint propagation rules, using the finite automata infrastructure introduced in the previous PR.
* **Automata Caching:** Introduced a cache for computed automata to avoid repeatedly constructing and evaluating the same automata during proof checking. This is particularly useful when the same regular language expressions occur across multiple proof steps.
