### PR TITLE
Operator type-checking rules

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,146 @@
+//! Reads `custom_operators.toml` and generates `$OUT_DIR/custom_operators.rs` at build time.
+
+use std::fmt::Write as _;
+
+/// One `[[operator]]` entry parsed from the config file.
+struct OperatorEntry {
+    name: String,
+    return_type: String,
+    arg_types: Vec<String>,
+}
+
+/// Maps a supported sort name to its `Sort` variant token, or `None` if unsupported.
+fn sort_token(name: &str) -> Option<&'static str> {
+    match name {
+        "Bool" => Some("Sort::Bool"),
+        "Int" => Some("Sort::Int"),
+        "Real" => Some("Sort::Real"),
+        "String" => Some("Sort::String"),
+        "RegLan" => Some("Sort::RegLan"),
+        _ => None,
+    }
+}
+
+/// Strips a `"..."` quoted string, panicking with `context` on malformed input.
+fn parse_quoted_string(value: &str, context: &str) -> String {
+    let value = value.trim();
+    let inner = value
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or_else(|| panic!("{context}: expected a quoted string, got `{value}`"));
+    inner.to_string()
+}
+
+/// Parses a `["a", "b", ...]` list of quoted strings, panicking with `context` on malformed input.
+fn parse_string_list(value: &str, context: &str) -> Vec<String> {
+    let value = value.trim();
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or_else(|| panic!("{context}: expected a `[...]` list, got `{value}`"));
+    let inner = inner.trim();
+    if inner.is_empty() {
+        return Vec::new();
+    }
+    inner
+        .split(',')
+        .map(|s| parse_quoted_string(s, context))
+        .collect()
+}
+
+/// Parses one `[[operator]]` chunk (the text following the `[[operator]]` marker, up to the next
+/// one) into an `OperatorEntry`.
+fn parse_operator_chunk(chunk: &str) -> OperatorEntry {
+    let mut name = None;
+    let mut return_type = None;
+    let mut arg_types = None;
+
+    for line in chunk.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (key, value) = line
+            .split_once('=')
+            .unwrap_or_else(|| panic!("malformed line in custom_operators.toml: `{line}`"));
+        let key = key.trim();
+        let value = value.trim();
+        match key {
+            "name" => name = Some(parse_quoted_string(value, "`name`")),
+            "return_type" => return_type = Some(parse_quoted_string(value, "`return_type`")),
+            "arg_types" => arg_types = Some(parse_string_list(value, "`arg_types`")),
+            other => panic!("unknown key `{other}` in custom_operators.toml"),
+        }
+    }
+
+    let name = name.unwrap_or_else(|| panic!("an [[operator]] entry is missing `name`"));
+    let return_type = return_type
+        .unwrap_or_else(|| panic!("[[operator]] entry `{name}` is missing `return_type`"));
+    let arg_types = arg_types.unwrap_or_default();
+
+    OperatorEntry { name, return_type, arg_types }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=custom_operators.toml");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let content = std::fs::read_to_string("custom_operators.toml")
+        .expect("failed to read custom_operators.toml");
+
+    // Drop comment/blank lines first, then split on `[[operator]]` marker lines, so a marker
+    // string mentioned inside a comment doesn't get mistaken for a real table-array marker.
+    let stripped: String = content
+        .lines()
+        .filter(|line| {
+            let line = line.trim();
+            !(line.is_empty() || line.starts_with('#'))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let mut chunks = stripped.split("[[operator]]");
+    chunks.next();
+
+    let mut entries = Vec::new();
+    let mut seen_names = std::collections::HashSet::new();
+    for chunk in chunks {
+        let entry = parse_operator_chunk(chunk);
+        if !seen_names.insert(entry.name.clone()) {
+            panic!("duplicate custom operator name `{}`", entry.name);
+        }
+        entries.push(entry);
+    }
+
+    let mut generated = String::new();
+    generated.push_str("pub static CUSTOM_OPERATORS: &[CustomOperatorDef] = &[\n");
+    for entry in &entries {
+        let return_sort = sort_token(&entry.return_type).unwrap_or_else(|| {
+            panic!(
+                "unknown sort `{}` for custom operator `{}`",
+                entry.return_type, entry.name
+            )
+        });
+        let arg_sorts: Vec<&str> = entry
+            .arg_types
+            .iter()
+            .map(|arg| {
+                sort_token(arg).unwrap_or_else(|| {
+                    panic!("unknown sort `{arg}` for custom operator `{}`", entry.name)
+                })
+            })
+            .collect();
+        writeln!(
+            generated,
+            "    CustomOperatorDef {{ name: {:?}, arg_sorts: &[{}], return_sort: {} }},",
+            entry.name,
+            arg_sorts.join(", "),
+            return_sort,
+        )
+        .unwrap();
+    }
+    generated.push_str("];\n");
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let out_path = std::path::Path::new(&out_dir).join("custom_operators.rs");
+    std::fs::write(out_path, generated).expect("failed to write custom_operators.rs");
+}

--- a/custom_operators.toml
+++ b/custom_operators.toml
@@ -1,0 +1,26 @@
+# Custom SMT-LIB operators, loaded by `build.rs` at compile time.
+# Each operator is declared with `[[operator]]`, `name`, `return_type`, and optional `arg_types`
+# (defaults to `[]` for nullary operators). Supported sorts: Bool, Int, Real, String, RegLan.
+#
+# The entries below are real cvc5 string extensions carcara doesn't implement as built-ins, see
+# https://cvc5.github.io/docs/cvc5-1.0.2/theories/strings.html
+
+[[operator]]
+name = "str.rev"
+return_type = "String"
+arg_types = ["String"]
+
+[[operator]]
+name = "str.to_lower"
+return_type = "String"
+arg_types = ["String"]
+
+[[operator]]
+name = "str.to_upper"
+return_type = "String"
+arg_types = ["String"]
+
+[[operator]]
+name = "str.update"
+return_type = "String"
+arg_types = ["String", "Int", "String"]

--- a/src/ast/custom_operator.rs
+++ b/src/ast/custom_operator.rs
@@ -1,0 +1,43 @@
+//! Custom operators, defined in `custom_operators.toml` and loaded at compile time.
+
+use super::Sort;
+
+/// The declared type signature of a custom operator.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct CustomOperatorDef {
+    pub name: &'static str,
+    pub arg_sorts: &'static [Sort],
+    pub return_sort: Sort,
+}
+
+/// A custom operator, defined via `custom_operators.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CustomOperator(pub &'static CustomOperatorDef);
+
+include!(concat!(env!("OUT_DIR"), "/custom_operators.rs"));
+
+/// Looks up an operator by name, checking built-in operators first, then custom ones.
+pub fn lookup_operator(name: &str) -> Option<super::Operator> {
+    use std::str::FromStr;
+    if let Ok(op) = super::Operator::from_str(name) {
+        return Some(op);
+    }
+    CUSTOM_OPERATORS
+        .iter()
+        .find(|def| def.name == name)
+        .map(|def| super::Operator::Custom(CustomOperator(def)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CUSTOM_OPERATORS;
+    use crate::ast::Operator;
+    use std::str::FromStr;
+
+    #[test]
+    fn custom_operator_names_do_not_shadow_built_ins() {
+        for def in CUSTOM_OPERATORS {
+            assert!(Operator::from_str(def.name).is_err());
+        }
+    }
+}

--- a/src/ast/evaluate.rs
+++ b/src/ast/evaluate.rs
@@ -695,7 +695,8 @@ fn eval_op(pool: &mut dyn TermPool, op: Operator, arg_terms: &[Rc<Term>]) -> Opt
         | Operator::RelTranspose
         | Operator::RelTclosure
         | Operator::RelJoin
-        | Operator::RelProduct => return None,
+        | Operator::RelProduct
+        | Operator::Custom(_) => return None,
     })
 }
 

--- a/src/ast/macros.rs
+++ b/src/ast/macros.rs
@@ -101,8 +101,12 @@ macro_rules! build_term {
 ///     assert_eq!(Foo::from_str("d"), Err(()));
 /// }
 /// ```
+// `|$f:ident|` names the formatter so call-site `extra_display` expressions can refer to it.
 macro_rules! impl_str_conversion_traits {
     ($enum_name:ident { $($variant:ident: $str:literal),* $(,)? }) => {
+        impl_str_conversion_traits!($enum_name { $($variant: $str),* }, extra_display: |f| {});
+    };
+    ($enum_name:ident { $($variant:ident: $str:literal),* $(,)? }, extra_display: |$f:ident| { $($extra_pat:pat => $extra_expr:expr),* $(,)? }) => {
         impl std::str::FromStr for $enum_name {
             type Err = ();
 
@@ -115,14 +119,14 @@ macro_rules! impl_str_conversion_traits {
         }
 
         impl std::fmt::Display for $enum_name {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                let s = match self {
-                    $($enum_name::$variant => $str,)*
-                };
-                write!(f, "{}", s)
+            fn fmt(&self, $f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                match self {
+                    $($enum_name::$variant => write!($f, "{}", $str),)*
+                    $($extra_pat => $extra_expr,)*
+                }
             }
         }
-    }
+    };
 }
 
 pub(crate) use {build_term, impl_str_conversion_traits, match_term_err};

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3,6 +3,7 @@
 //! This module also contains various utilities for manipulating Alethe proofs and terms.
 
 mod context;
+mod custom_operator;
 mod evaluate;
 mod iter;
 mod macros;
@@ -20,6 +21,7 @@ mod term;
 #[cfg(test)]
 mod tests;
 
+pub use custom_operator::{CustomOperator, CustomOperatorDef};
 pub use evaluate::Value;
 pub use iter::ProofIter;
 pub use node::{ProofNode, ProofNodeForest, StepNode, SubproofNode};
@@ -36,6 +38,7 @@ pub use term::{
 
 pub(crate) use carcara_macros::match_term;
 pub(crate) use context::ContextStack;
+pub(crate) use custom_operator::lookup_operator;
 pub(crate) use macros::{build_term, impl_str_conversion_traits, match_term_err};
 
 #[cfg(test)]

--- a/src/ast/pool/mod.rs
+++ b/src/ast/pool/mod.rs
@@ -361,6 +361,7 @@ impl PrimitivePool {
                     let tuple = self.sorts.add(Sort::Tuple(left));
                     self.sorts.add(Sort::Set(tuple))
                 }
+                Operator::Custom(custom) => self.sorts.add(custom.0.return_sort.clone()),
             },
             Term::App(f, args) => {
                 let func_sort = self.compute_sort(f).clone();

--- a/src/ast/term.rs
+++ b/src/ast/term.rs
@@ -1,5 +1,6 @@
 use super::{
     Rc, Sort,
+    custom_operator::CustomOperator,
     macros::impl_str_conversion_traits,
     match_term, match_term_err,
     pool::{PrimitivePool, TermPool},
@@ -548,6 +549,9 @@ pub enum Operator {
 
     /// The `rel.product` operator.
     RelProduct,
+
+    /// A custom operator, defined via `custom_operators.toml`.
+    Custom(CustomOperator),
 }
 
 /// A case for a `match` term.
@@ -770,6 +774,8 @@ impl Operator {
             | Operator::RelTclosure
             | Operator::RelJoin
             | Operator::RelProduct => None,
+
+            Operator::Custom(_) => None,
         }
     }
 }
@@ -974,6 +980,8 @@ impl_str_conversion_traits!(Operator {
     RelTclosure: "rel.tclosure",
     RelJoin: "rel.join",
     RelProduct: "rel.product",
+}, extra_display: |f| {
+    Operator::Custom(op) => write!(f, "{}", op.0.name),
 });
 
 impl_str_conversion_traits!(ParamOperator {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,6 +3,7 @@
 mod datatypes;
 mod error;
 mod lexer;
+mod operators;
 mod rare;
 pub(crate) mod tests;
 
@@ -11,15 +12,14 @@ use crate::{
     ast::{
         AnchorArg, Binder, BindingList, Constant, Operator, ParamOperator, Problem, ProblemPrelude,
         Proof, ProofCommand, ProofStep, QualifiedOperator, Rc, Sort, SortSubstitution, SortedVar,
-        Subproof, Substitution, Term, build_term,
+        Subproof, Substitution, Term, build_term, lookup_operator,
         pool::{PrimitivePool, TermPool},
         rare_rules::{RareStatements, Rules},
     },
-    automata::parser::parse_automaton,
     utils::{HashCache, HashMapStack},
 };
 use carcara_macros::GenerateSetters;
-use error::{assert_indexed_op_args_value, assert_num_args, check_relation_sort, check_set_sort};
+use error::{assert_indexed_op_args_value, assert_num_args, check_set_sort};
 use indexmap::{IndexMap, IndexSet};
 use rapidhash::{HashMapExt, RapidHashMap};
 use rug::{Integer, Rational};
@@ -419,400 +419,8 @@ impl<'p, 's> Parser<'p, 's> {
     /// Constructs and sort checks an operation term.
     fn make_op(&mut self, op: Operator, args: Vec<Rc<Term>>) -> Result<Rc<Term>, ParserError> {
         let sorts: Vec<_> = args.iter().map(|t| self.pool.sort(t)).collect();
-
-        match op {
-            Operator::True | Operator::False => assert_num_args(&args, 0)?,
-            Operator::Not => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::Bool, &sorts[0])?;
-            }
-            Operator::Implies => {
-                assert_num_args(&args, 2..)?;
-                for s in sorts {
-                    self.check_sort_eq(&Sort::Bool, &s)?;
-                }
-            }
-            Operator::Or | Operator::And | Operator::Xor => {
-                // If we are not in "strict" parsing mode, we allow these operators to be called
-                // with just one argument
-                assert_num_args(&args, if self.config.strict { 2.. } else { 1.. })?;
-                for s in sorts {
-                    self.check_sort_eq(&Sort::Bool, &s)?;
-                }
-            }
-            Operator::Equals | Operator::Distinct => {
-                assert_num_args(&args, 2..)?;
-                self.check_sort_all_eq(&sorts)?;
-            }
-            Operator::Ite => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::Bool, &sorts[0])?;
-                self.check_sort_eq(sorts[1].as_ref(), &sorts[2])?;
-            }
-            Operator::Add | Operator::Sub | Operator::Mult => {
-                // The `-` operator, in particular, can be called with only one argument, in which
-                // case it means negation instead of subtraction
-                if op == Operator::Sub {
-                    assert_num_args(&args, 1..)?;
-                } else {
-                    assert_num_args(&args, 2..)?;
-                }
-
-                // All the arguments must be either Int or Real. Also, if we are not allowing
-                // Int/Real subtyping, all arguments must have the same sort
-                if self.config.allow_int_real_subtyping {
-                    for s in sorts {
-                        self.check_sort_one_of(&[Sort::Int, Sort::Real], &s)?;
-                    }
-                } else {
-                    self.check_sort_one_of(&[Sort::Int, Sort::Real], &sorts[0])?;
-                    self.check_sort_all_eq(&sorts)?;
-                }
-            }
-            Operator::IntDiv => {
-                assert_num_args(&args, 2..)?;
-                self.check_sort_eq(&Sort::Int, &sorts[0])?;
-                self.check_sort_all_eq(&sorts)?;
-            }
-            Operator::RealDiv => {
-                assert_num_args(&args, 2..)?;
-
-                // Normally, the `/` operator may only receive Real arguments, but if we are
-                // allowing Int/Real subtyping, it may also receive Ints
-                if self.config.allow_int_real_subtyping {
-                    for s in sorts {
-                        self.check_sort_one_of(&[Sort::Int, Sort::Real], &s)?;
-                    }
-                } else {
-                    self.check_sort_eq(&Sort::Real, &sorts[0])?;
-                    self.check_sort_all_eq(&sorts)?;
-                }
-
-                if let Some(r) = self.interpret_div_as_real_lit(&args[0], &args[1]) {
-                    return Ok(r);
-                }
-            }
-            Operator::Mod => {
-                assert_num_args(&args, 2)?;
-                self.check_sort_eq(&Sort::Int, &sorts[0])?;
-                self.check_sort_eq(&Sort::Int, &sorts[1])?;
-            }
-            Operator::Abs => {
-                assert_num_args(&args, 1)?;
-                // The argument must be Int unless we are allowing Int/Real subtyping
-                if self.config.allow_int_real_subtyping {
-                    self.check_sort_one_of(&[Sort::Int, Sort::Real], &sorts[0])?;
-                } else {
-                    self.check_sort_eq(&Sort::Int, &sorts[0])?;
-                }
-            }
-            Operator::LessThan | Operator::GreaterThan | Operator::LessEq | Operator::GreaterEq => {
-                assert_num_args(&args, 2..)?;
-                // All the arguments must be either Int or Real sorted, but they don't need to all
-                // have the same sort
-                for s in sorts {
-                    self.check_sort_one_of(&[Sort::Int, Sort::Real], &s)?;
-                }
-            }
-            Operator::ToReal => {
-                assert_num_args(&args, 1)?;
-                // If the logic contains reals but not integers, integer constants are interpreted
-                // as reals, so the argument might have sort Real instead of the expected Int
-                self.check_sort_one_of(&[Sort::Int, Sort::Real], &sorts[0])?;
-            }
-            Operator::ToInt | Operator::IsInt => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::Real, &sorts[0])?;
-            }
-            Operator::Select => {
-                assert_num_args(&args, 2)?;
-                self.check_array_sort(Some(&sorts[1]), None, &sorts[0])?;
-            }
-            Operator::Store => {
-                assert_num_args(&args, 3)?;
-                self.check_array_sort(Some(&sorts[1]), Some(&sorts[2]), &sorts[0])?;
-            }
-            Operator::StrConcat => {
-                assert_num_args(&args, 2..)?;
-                for s in sorts {
-                    self.check_sort_eq(&Sort::String, &s)?;
-                }
-            }
-            Operator::StrLen | Operator::StrIsDigit | Operator::StrToCode | Operator::StrToInt => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-            }
-            Operator::StrLessThan
-            | Operator::StrLessEq
-            | Operator::PrefixOf
-            | Operator::SuffixOf
-            | Operator::Contains
-            | Operator::ReRange => {
-                assert_num_args(&args, 2)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::String, &sorts[1])?;
-            }
-            Operator::CharAt => {
-                assert_num_args(&args, 2)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::Int, &sorts[1])?;
-            }
-            Operator::Substring => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::Int, &sorts[1])?;
-                self.check_sort_eq(&Sort::Int, &sorts[2])?;
-            }
-            Operator::IndexOf => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::String, &sorts[1])?;
-                self.check_sort_eq(&Sort::Int, &sorts[2])?;
-            }
-            Operator::IndexOfRe => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::RegLan, &sorts[1])?;
-                self.check_sort_eq(&Sort::Int, &sorts[2])?;
-            }
-            Operator::Replace | Operator::ReplaceAll => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::String, &sorts[1])?;
-                self.check_sort_eq(&Sort::String, &sorts[2])?;
-            }
-            Operator::ReFromAutomaton => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                if let Term::Const(Constant::String(s)) = args[0].as_ref() {
-                    let automata = match parse_automaton(s.trim()) {
-                        Ok((remaining, automata)) => {
-                            if !remaining.is_empty() {
-                                return Err(ParserError::InvalidAutomatonDeclaration(s.clone()));
-                            }
-                            Ok(automata)
-                        }
-                        Err(_) => Err(ParserError::InvalidAutomatonDeclaration(s.clone())),
-                    }?;
-                    return Ok(self
-                        .pool
-                        .add(Term::Const(Constant::RegLan(s.to_owned(), automata))));
-                } else {
-                    return Err(ParserError::ExpectedAnAutomatonDeclaration(args[0].clone()));
-                }
-            }
-            Operator::StrFromCode | Operator::StrFromInt => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::Int, &sorts[0])?;
-            }
-            Operator::StrToRe => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-            }
-            Operator::StrInRe => {
-                assert_num_args(&args, 2)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::RegLan, &sorts[1])?;
-            }
-            Operator::ReNone | Operator::ReAll | Operator::ReAllChar => {
-                assert_num_args(&args, 0)?;
-            }
-            Operator::ReConcat
-            | Operator::ReUnion
-            | Operator::ReIntersection
-            | Operator::ReDiff => {
-                assert_num_args(&args, 2..)?;
-                for s in sorts {
-                    self.check_sort_eq(&Sort::RegLan, &s)?;
-                }
-            }
-            Operator::ReKleeneClosure
-            | Operator::ReComplement
-            | Operator::ReKleeneCross
-            | Operator::ReOption => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::RegLan, &sorts[0])?;
-            }
-            Operator::ReplaceRe | Operator::ReplaceReAll => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::String, &sorts[0])?;
-                self.check_sort_eq(&Sort::RegLan, &sorts[1])?;
-                self.check_sort_eq(&Sort::String, &sorts[2])?;
-            }
-            Operator::BvNot | Operator::BvNeg => {
-                assert_num_args(&args, 1)?;
-                for s in sorts {
-                    if !s.is_bitvec() {
-                        return Err(ParserError::ExpectedBvSort(s));
-                    }
-                }
-            }
-            Operator::BvSize | Operator::UBvToInt | Operator::SBvToInt => {
-                assert_num_args(&args, 1)?;
-                if !sorts[0].is_bitvec() {
-                    return Err(ParserError::ExpectedBvSort(sorts[0].clone()));
-                }
-            }
-            Operator::BvBbTerm => {
-                assert_num_args(&args, 1..)?;
-                self.check_sort_eq(&Sort::Bool, &sorts[0])?;
-                self.check_sort_all_eq(&sorts)?;
-            }
-            Operator::BvPBbTerm => {
-                assert_num_args(&args, 1..)?;
-                self.check_sort_eq(&Sort::Int, &sorts[0])?;
-                self.check_sort_all_eq(&sorts)?;
-            }
-            Operator::BvConst => {
-                assert_num_args(&args, 2)?;
-                self.check_sort_eq(&Sort::Int, &sorts[0])?;
-                self.check_sort_eq(&Sort::Int, &sorts[1])?;
-            }
-            Operator::BvConcat => {
-                assert_num_args(&args, 2..)?;
-                for s in sorts {
-                    if !s.is_bitvec() {
-                        return Err(ParserError::ExpectedBvSort(s));
-                    }
-                }
-            }
-            Operator::Cl => {}
-            Operator::Delete => {
-                self.check_sort_eq(&Sort::Bool, &sorts[0])?;
-                assert_num_args(&args, 1)?;
-            }
-            Operator::BvAdd
-            | Operator::BvMul
-            | Operator::BvAnd
-            | Operator::BvOr
-            | Operator::BvXor => {
-                assert_num_args(&args, 2..)?;
-                if !sorts[0].is_bitvec() {
-                    return Err(ParserError::ExpectedBvSort(sorts[0].clone()));
-                }
-                self.check_sort_all_eq(&sorts)?;
-            }
-            Operator::BvUDiv
-            | Operator::BvURem
-            | Operator::BvShl
-            | Operator::BvLShr
-            | Operator::BvULt
-            | Operator::BvNAnd
-            | Operator::BvNOr
-            | Operator::BvXNor
-            | Operator::BvComp
-            | Operator::BvSub
-            | Operator::BvSDiv
-            | Operator::BvSRem
-            | Operator::BvSMod
-            | Operator::BvAShr
-            | Operator::BvULe
-            | Operator::BvUGt
-            | Operator::BvUGe
-            | Operator::BvSLt
-            | Operator::BvSLe
-            | Operator::BvSGt
-            | Operator::BvSGe => {
-                assert_num_args(&args, 2)?;
-                if !sorts[0].is_bitvec() {
-                    return Err(ParserError::ExpectedBvSort(sorts[0].clone()));
-                }
-                self.check_sort_all_eq(&sorts)?;
-            }
-            Operator::BvIte => {
-                assert_num_args(&args, 3)?;
-                self.check_sort_eq(&Sort::BitVec(1), &sorts[0])?;
-                self.check_sort_all_eq(&sorts[1..])?;
-            }
-            Operator::RareList => (),
-            Operator::Pow2 | Operator::Log2 | Operator::IsPow2 => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::Int, &sorts[0])?;
-            }
-            Operator::RealPi => assert_num_args(&args, 0)?,
-            Operator::Sqrt
-            | Operator::Exp
-            | Operator::Sin
-            | Operator::Cos
-            | Operator::Tan
-            | Operator::Csc
-            | Operator::Sec
-            | Operator::Cot
-            | Operator::Arcsin
-            | Operator::Arccos
-            | Operator::Arctan
-            | Operator::Arccsc
-            | Operator::Arcsec
-            | Operator::Arccot => {
-                assert_num_args(&args, 1)?;
-                self.check_sort_eq(&Sort::Real, &sorts[0])?;
-            }
-            Operator::SetUnion | Operator::SetInter | Operator::SetMinus | Operator::SetSubset => {
-                assert_num_args(&args, 2)?;
-                self.check_sort_all_eq(&sorts)?;
-                for sort in sorts {
-                    check_set_sort(&sort)?;
-                }
-            }
-            Operator::SetMember => {
-                assert_num_args(&args, 2)?;
-                let expected = self.pool.add_sort(Sort::Set(sorts[0].clone()));
-                self.check_sort_eq(&expected, &sorts[1])?;
-            }
-            Operator::SetSingleton => {
-                assert_num_args(&args, 1)?;
-            }
-            Operator::SetIsEmpty
-            | Operator::SetIsSingleton
-            | Operator::SetCard
-            | Operator::SetComplement => {
-                assert_num_args(&args, 1)?;
-                check_set_sort(&sorts[0])?;
-            }
-            Operator::SetInsert => {
-                assert_num_args(&args, 2..)?;
-                self.check_sort_all_eq(&sorts[..sorts.len() - 1])?;
-                let expected = self.pool.add_sort(Sort::Set(sorts[0].clone()));
-                self.check_sort_eq(&expected, sorts.last().unwrap())?;
-            }
-            Operator::Tuple => {
-                assert_num_args(&args, 1..)?;
-            }
-            Operator::TupleUnit => {
-                assert_num_args(&args, 0)?;
-            }
-            Operator::RelTranspose => {
-                assert_num_args(&args, 1)?;
-                check_relation_sort(&sorts[0])?;
-            }
-            Operator::RelTclosure => {
-                assert_num_args(&args, 1)?;
-                check_relation_sort(&sorts[0])?;
-                let Sort::Set(tuple) = sorts[0].as_ref() else {
-                    unreachable!()
-                };
-                let Sort::Tuple(elems) = tuple.as_ref() else {
-                    unreachable!()
-                };
-                if elems.len() != 2 {
-                    // Hacky way to print an error saying the relation should be binary
-                    let any = self.pool.add_sort(Sort::Var("?".into()));
-                    let tuple = self.pool.add_sort(Sort::Tuple(vec![any.clone(), any]));
-                    let expected = vec![self.pool.add_sort(Sort::Set(tuple))].into_boxed_slice();
-                    return Err(SortError { expected, got: sorts[0].clone() }.into());
-                }
-            }
-            Operator::RelJoin => {
-                assert_num_args(&args, 2)?;
-                check_relation_sort(&sorts[0])?;
-                check_relation_sort(&sorts[1])?;
-                // TODO: check properly
-            }
-            Operator::RelProduct => {
-                assert_num_args(&args, 2)?;
-                check_relation_sort(&sorts[0])?;
-                check_relation_sort(&sorts[1])?;
-            }
+        if let Some(term) = operators::check_op_types(self, op, &args, &sorts)? {
+            return Ok(term);
         }
         Ok(self.pool.add(Term::Op(op, args)))
     }
@@ -1621,7 +1229,7 @@ impl<'p, 's> Parser<'p, 's> {
                 return if let Some(func) = self.state.function_defs.get(&s) {
                     func.apply(self.pool, Vec::new())
                         .map_err(|err| self.err(err, pos))
-                } else if let Ok(op) = Operator::from_str(&s) {
+                } else if let Some(op) = lookup_operator(&s) {
                     let args = Vec::new();
 
                     self.make_op(op, args).map_err(|err| self.err(err, pos))
@@ -2012,8 +1620,8 @@ impl<'p, 's> Parser<'p, 's> {
             //
             // However, `if let` guards are still nightly only. For more info, see:
             // https://github.com/rust-lang/rust/issues/51114
-            Token::Symbol(s) if Operator::from_str(s).is_ok() => {
-                let operator = Operator::from_str(s).unwrap();
+            Token::Symbol(s) if lookup_operator(s).is_some() => {
+                let operator = lookup_operator(s).unwrap();
                 self.next_token()?;
                 let args = self.parse_sequence(Self::parse_term, true)?;
                 self.make_op(operator, args)

--- a/src/parser/operators.rs
+++ b/src/parser/operators.rs
@@ -1,0 +1,451 @@
+//! A declarative rule DSL for type-checking SMT-LIB operators, used by `Parser::make_op`.
+
+use super::{
+    Parser,
+    error::{ParserError, SortError, assert_num_args, check_relation_sort, check_set_sort},
+};
+use crate::{
+    ast::{Constant, Operator, Rc, Sort, Term, pool::TermPool},
+    automata::parser::parse_automaton,
+    utils::Range,
+};
+
+/// The sorts a single operator argument is allowed to have.
+enum ArgSort {
+    /// The argument must have exactly this sort.
+    Exact(Sort),
+    /// The argument must have one of these sorts.
+    OneOf(&'static [Sort]),
+    /// The argument must have any bitvector sort.
+    AnyBitVec,
+    /// The argument's sort must satisfy this predicate.
+    Predicate(fn(&Rc<Sort>) -> Result<(), ParserError>),
+}
+
+impl ArgSort {
+    /// Checks that `sort` satisfies this constraint.
+    fn check(&self, parser: &mut Parser, sort: &Rc<Sort>) -> Result<(), ParserError> {
+        match self {
+            ArgSort::Exact(expected) => Ok(parser.check_sort_eq(expected, sort)?),
+            ArgSort::OneOf(possibilities) => Ok(parser.check_sort_one_of(possibilities, sort)?),
+            ArgSort::AnyBitVec if sort.is_bitvec() => Ok(()),
+            ArgSort::AnyBitVec => Err(ParserError::ExpectedBvSort(sort.clone())),
+            ArgSort::Predicate(f) => f(sort),
+        }
+    }
+}
+
+/// How the sorts of an operator's arguments, as a whole, should be checked.
+enum ArgsCheck {
+    /// No per-argument sort checks.
+    Unconstrained,
+    /// Every argument independently satisfies this constraint.
+    Each(ArgSort),
+    /// The first argument satisfies this constraint, then all arguments are pairwise equal.
+    FirstThenAllEq(ArgSort),
+    /// All arguments are pairwise equal, with no other constraint.
+    AllEq,
+    /// All arguments are pairwise equal, and each independently satisfies this constraint.
+    AllEqAndEach(ArgSort),
+    /// One explicit constraint per argument position.
+    Positional(&'static [ArgSort]),
+}
+
+impl ArgsCheck {
+    /// Checks that `sorts` satisfies this constraint.
+    fn check(&self, parser: &mut Parser, sorts: &[Rc<Sort>]) -> Result<(), ParserError> {
+        match self {
+            ArgsCheck::Unconstrained => Ok(()),
+            ArgsCheck::Each(arg_sort) => {
+                for sort in sorts {
+                    arg_sort.check(parser, sort)?;
+                }
+                Ok(())
+            }
+            ArgsCheck::FirstThenAllEq(arg_sort) => {
+                arg_sort.check(parser, &sorts[0])?;
+                Ok(parser.check_sort_all_eq(sorts)?)
+            }
+            ArgsCheck::AllEq => Ok(parser.check_sort_all_eq(sorts)?),
+            ArgsCheck::AllEqAndEach(arg_sort) => {
+                parser.check_sort_all_eq(sorts)?;
+                for sort in sorts {
+                    arg_sort.check(parser, sort)?;
+                }
+                Ok(())
+            }
+            ArgsCheck::Positional(arg_sorts) => {
+                for (arg_sort, sort) in arg_sorts.iter().zip(sorts) {
+                    arg_sort.check(parser, sort)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// How an operator's arity should be checked.
+enum ArityRule {
+    /// A fixed arity range.
+    Fixed(Range),
+    /// The allowed arity range depends on whether the parser is in "strict" mode.
+    StrictDependent { strict: Range, lenient: Range },
+}
+
+/// A declarative type-checking rule for an operator.
+struct Rule {
+    arity: ArityRule,
+    args: ArgsCheck,
+}
+
+impl Rule {
+    /// Creates a rule with a fixed arity range.
+    fn arity(range: impl Into<Range>, args: ArgsCheck) -> Self {
+        Self {
+            arity: ArityRule::Fixed(range.into()),
+            args,
+        }
+    }
+
+    /// Creates a rule whose arity range depends on the parser's "strict" mode setting.
+    fn strict_arity(strict: impl Into<Range>, lenient: impl Into<Range>, args: ArgsCheck) -> Self {
+        Self {
+            arity: ArityRule::StrictDependent {
+                strict: strict.into(),
+                lenient: lenient.into(),
+            },
+            args,
+        }
+    }
+
+    /// Checks that `sorts` satisfies this rule's arity and argument sort constraints.
+    fn check(self, parser: &mut Parser, sorts: &[Rc<Sort>]) -> Result<(), ParserError> {
+        let range = match self.arity {
+            ArityRule::Fixed(range) => range,
+            ArityRule::StrictDependent { strict, lenient } => {
+                if parser.config.strict {
+                    strict
+                } else {
+                    lenient
+                }
+            }
+        };
+        assert_num_args(sorts, range)?;
+        self.args.check(parser, sorts)
+    }
+}
+
+/// The sorts `Int` and `Real`, used by several arithmetic operators.
+const INT_OR_REAL: &[Sort] = &[Sort::Int, Sort::Real];
+
+/// Builds the `ArgsCheck` shared by `+`, `-` and `*`, which depends on Int/Real subtyping.
+fn int_or_real_args(subtyping: bool) -> ArgsCheck {
+    if subtyping {
+        ArgsCheck::Each(ArgSort::OneOf(INT_OR_REAL))
+    } else {
+        ArgsCheck::FirstThenAllEq(ArgSort::OneOf(INT_OR_REAL))
+    }
+}
+
+/// Whether an operator's type checking is expressed declaratively or requires custom logic.
+enum OpCheck {
+    Rule(Rule),
+    Custom,
+}
+
+/// Returns the type-checking behavior for `op`, given whether Int/Real subtyping is allowed.
+fn op_check(op: Operator, subtyping: bool) -> OpCheck {
+    use ArgSort::{AnyBitVec, Exact, OneOf, Predicate};
+    use ArgsCheck::{AllEq, AllEqAndEach, Each, FirstThenAllEq, Positional, Unconstrained};
+
+    match op {
+        Operator::True | Operator::False => OpCheck::Rule(Rule::arity(0, Unconstrained)),
+        Operator::Not => OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::Bool)))),
+        Operator::Implies => OpCheck::Rule(Rule::arity(2.., Each(Exact(Sort::Bool)))),
+        Operator::Or | Operator::And | Operator::Xor => {
+            OpCheck::Rule(Rule::strict_arity(2.., 1.., Each(Exact(Sort::Bool))))
+        }
+        Operator::Equals | Operator::Distinct => OpCheck::Rule(Rule::arity(2.., AllEq)),
+        Operator::Ite => OpCheck::Custom,
+        Operator::Add | Operator::Mult => {
+            OpCheck::Rule(Rule::arity(2.., int_or_real_args(subtyping)))
+        }
+        Operator::Sub => OpCheck::Rule(Rule::arity(1.., int_or_real_args(subtyping))),
+        Operator::IntDiv => OpCheck::Rule(Rule::arity(2.., FirstThenAllEq(Exact(Sort::Int)))),
+        Operator::RealDiv => OpCheck::Custom,
+        Operator::Mod => OpCheck::Rule(Rule::arity(
+            2,
+            Positional(&[Exact(Sort::Int), Exact(Sort::Int)]),
+        )),
+        Operator::Abs => {
+            let args = if subtyping {
+                Each(OneOf(INT_OR_REAL))
+            } else {
+                Each(Exact(Sort::Int))
+            };
+            OpCheck::Rule(Rule::arity(1, args))
+        }
+        Operator::LessThan | Operator::GreaterThan | Operator::LessEq | Operator::GreaterEq => {
+            OpCheck::Rule(Rule::arity(2.., Each(OneOf(INT_OR_REAL))))
+        }
+        Operator::ToReal => OpCheck::Rule(Rule::arity(1, Each(OneOf(INT_OR_REAL)))),
+        Operator::ToInt | Operator::IsInt => OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::Real)))),
+        Operator::Select => OpCheck::Custom,
+        Operator::Store => OpCheck::Custom,
+        Operator::StrConcat => OpCheck::Rule(Rule::arity(2.., Each(Exact(Sort::String)))),
+        Operator::StrLen | Operator::StrIsDigit | Operator::StrToCode | Operator::StrToInt => {
+            OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::String))))
+        }
+        Operator::StrLessThan
+        | Operator::StrLessEq
+        | Operator::PrefixOf
+        | Operator::SuffixOf
+        | Operator::Contains
+        | Operator::ReRange => OpCheck::Rule(Rule::arity(2, Each(Exact(Sort::String)))),
+        Operator::CharAt => OpCheck::Rule(Rule::arity(
+            2,
+            Positional(&[Exact(Sort::String), Exact(Sort::Int)]),
+        )),
+        Operator::Substring => OpCheck::Rule(Rule::arity(
+            3,
+            Positional(&[Exact(Sort::String), Exact(Sort::Int), Exact(Sort::Int)]),
+        )),
+        Operator::IndexOf => OpCheck::Rule(Rule::arity(
+            3,
+            Positional(&[Exact(Sort::String), Exact(Sort::String), Exact(Sort::Int)]),
+        )),
+        Operator::IndexOfRe => OpCheck::Rule(Rule::arity(
+            3,
+            Positional(&[Exact(Sort::String), Exact(Sort::RegLan), Exact(Sort::Int)]),
+        )),
+        Operator::Replace | Operator::ReplaceAll => {
+            OpCheck::Rule(Rule::arity(3, Each(Exact(Sort::String))))
+        }
+        Operator::ReFromAutomaton => OpCheck::Custom,
+        Operator::StrFromCode | Operator::StrFromInt => {
+            OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::Int))))
+        }
+        Operator::StrToRe => OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::String)))),
+        Operator::StrInRe => OpCheck::Rule(Rule::arity(
+            2,
+            Positional(&[Exact(Sort::String), Exact(Sort::RegLan)]),
+        )),
+        Operator::ReNone | Operator::ReAll | Operator::ReAllChar => {
+            OpCheck::Rule(Rule::arity(0, Unconstrained))
+        }
+        Operator::ReConcat | Operator::ReUnion | Operator::ReIntersection | Operator::ReDiff => {
+            OpCheck::Rule(Rule::arity(2.., Each(Exact(Sort::RegLan))))
+        }
+        Operator::ReKleeneClosure
+        | Operator::ReComplement
+        | Operator::ReKleeneCross
+        | Operator::ReOption => OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::RegLan)))),
+        Operator::ReplaceRe | Operator::ReplaceReAll => OpCheck::Rule(Rule::arity(
+            3,
+            Positional(&[
+                Exact(Sort::String),
+                Exact(Sort::RegLan),
+                Exact(Sort::String),
+            ]),
+        )),
+        Operator::BvNot | Operator::BvNeg => OpCheck::Rule(Rule::arity(1, Each(AnyBitVec))),
+        Operator::BvSize | Operator::UBvToInt | Operator::SBvToInt => {
+            OpCheck::Rule(Rule::arity(1, Each(AnyBitVec)))
+        }
+        Operator::BvBbTerm => OpCheck::Rule(Rule::arity(1.., FirstThenAllEq(Exact(Sort::Bool)))),
+        Operator::BvPBbTerm => OpCheck::Rule(Rule::arity(1.., FirstThenAllEq(Exact(Sort::Int)))),
+        Operator::BvConst => OpCheck::Rule(Rule::arity(2, Each(Exact(Sort::Int)))),
+        // Note: not all-equal here -- different bitvector widths are allowed in `concat`
+        Operator::BvConcat => OpCheck::Rule(Rule::arity(2.., Each(AnyBitVec))),
+        Operator::Cl => OpCheck::Rule(Rule::arity(.., Unconstrained)),
+        Operator::Delete => OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::Bool)))),
+        Operator::BvAdd | Operator::BvMul | Operator::BvAnd | Operator::BvOr | Operator::BvXor => {
+            OpCheck::Rule(Rule::arity(2.., FirstThenAllEq(AnyBitVec)))
+        }
+        Operator::BvUDiv
+        | Operator::BvURem
+        | Operator::BvShl
+        | Operator::BvLShr
+        | Operator::BvULt
+        | Operator::BvNAnd
+        | Operator::BvNOr
+        | Operator::BvXNor
+        | Operator::BvComp
+        | Operator::BvSub
+        | Operator::BvSDiv
+        | Operator::BvSRem
+        | Operator::BvSMod
+        | Operator::BvAShr
+        | Operator::BvULe
+        | Operator::BvUGt
+        | Operator::BvUGe
+        | Operator::BvSLt
+        | Operator::BvSLe
+        | Operator::BvSGt
+        | Operator::BvSGe => OpCheck::Rule(Rule::arity(2, FirstThenAllEq(AnyBitVec))),
+        Operator::BvIte => OpCheck::Custom,
+        Operator::RareList => OpCheck::Rule(Rule::arity(.., Unconstrained)),
+        Operator::Pow2 | Operator::Log2 | Operator::IsPow2 => {
+            OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::Int))))
+        }
+        Operator::RealPi => OpCheck::Rule(Rule::arity(0, Unconstrained)),
+        Operator::Sqrt
+        | Operator::Exp
+        | Operator::Sin
+        | Operator::Cos
+        | Operator::Tan
+        | Operator::Csc
+        | Operator::Sec
+        | Operator::Cot
+        | Operator::Arcsin
+        | Operator::Arccos
+        | Operator::Arctan
+        | Operator::Arccsc
+        | Operator::Arcsec
+        | Operator::Arccot => OpCheck::Rule(Rule::arity(1, Each(Exact(Sort::Real)))),
+        Operator::SetUnion | Operator::SetInter | Operator::SetMinus | Operator::SetSubset => {
+            OpCheck::Rule(Rule::arity(2, AllEqAndEach(Predicate(check_set_sort))))
+        }
+        // Note: `set.singleton` genuinely has no sort check in the original code
+        Operator::SetSingleton => OpCheck::Rule(Rule::arity(1, Unconstrained)),
+        Operator::SetMember => OpCheck::Custom,
+        Operator::SetIsEmpty
+        | Operator::SetIsSingleton
+        | Operator::SetCard
+        | Operator::SetComplement => OpCheck::Rule(Rule::arity(1, Each(Predicate(check_set_sort)))),
+        Operator::SetInsert => OpCheck::Custom,
+        Operator::Tuple => OpCheck::Rule(Rule::arity(1.., Unconstrained)),
+        Operator::TupleUnit => OpCheck::Rule(Rule::arity(0, Unconstrained)),
+        Operator::RelTranspose => {
+            OpCheck::Rule(Rule::arity(1, Each(Predicate(check_relation_sort))))
+        }
+        Operator::RelTclosure => OpCheck::Custom,
+        // TODO: `rel.join`/`rel.product` sort checking could be more precise
+        Operator::RelJoin | Operator::RelProduct => {
+            OpCheck::Rule(Rule::arity(2, Each(Predicate(check_relation_sort))))
+        }
+        Operator::Custom(_) => OpCheck::Custom,
+    }
+}
+
+/// Handles type checking for the operators whose rules don't fit the declarative `Rule` DSL.
+fn custom_check(
+    parser: &mut Parser,
+    op: Operator,
+    args: &[Rc<Term>],
+    sorts: &[Rc<Sort>],
+) -> Result<Option<Rc<Term>>, ParserError> {
+    match op {
+        Operator::Ite => {
+            assert_num_args(sorts, 3)?;
+            parser.check_sort_eq(&Sort::Bool, &sorts[0])?;
+            parser.check_sort_eq(sorts[1].as_ref(), &sorts[2])?;
+            Ok(None)
+        }
+        Operator::RealDiv => {
+            // Normally, the `/` operator may only receive Real arguments, but if we are allowing
+            // Int/Real subtyping, it may also receive Ints
+            let args_check = if parser.config.allow_int_real_subtyping {
+                ArgsCheck::Each(ArgSort::OneOf(INT_OR_REAL))
+            } else {
+                ArgsCheck::FirstThenAllEq(ArgSort::Exact(Sort::Real))
+            };
+            Rule::arity(2.., args_check).check(parser, sorts)?;
+            Ok(parser.interpret_div_as_real_lit(&args[0], &args[1]))
+        }
+        Operator::Select => {
+            assert_num_args(sorts, 2)?;
+            parser.check_array_sort(Some(&sorts[1]), None, &sorts[0])?;
+            Ok(None)
+        }
+        Operator::Store => {
+            assert_num_args(sorts, 3)?;
+            parser.check_array_sort(Some(&sorts[1]), Some(&sorts[2]), &sorts[0])?;
+            Ok(None)
+        }
+        Operator::ReFromAutomaton => {
+            assert_num_args(sorts, 1)?;
+            parser.check_sort_eq(&Sort::String, &sorts[0])?;
+            if let Term::Const(Constant::String(s)) = args[0].as_ref() {
+                let automata = match parse_automaton(s.trim()) {
+                    Ok((remaining, automata)) => {
+                        if !remaining.is_empty() {
+                            return Err(ParserError::InvalidAutomatonDeclaration(s.clone()));
+                        }
+                        Ok(automata)
+                    }
+                    Err(_) => Err(ParserError::InvalidAutomatonDeclaration(s.clone())),
+                }?;
+                Ok(Some(parser.pool.add(Term::Const(Constant::RegLan(
+                    s.to_owned(),
+                    automata,
+                )))))
+            } else {
+                Err(ParserError::ExpectedAnAutomatonDeclaration(args[0].clone()))
+            }
+        }
+        Operator::SetMember => {
+            assert_num_args(sorts, 2)?;
+            let expected = parser.pool.add_sort(Sort::Set(sorts[0].clone()));
+            parser.check_sort_eq(&expected, &sorts[1])?;
+            Ok(None)
+        }
+        Operator::SetInsert => {
+            assert_num_args(sorts, 2..)?;
+            parser.check_sort_all_eq(&sorts[..sorts.len() - 1])?;
+            let expected = parser.pool.add_sort(Sort::Set(sorts[0].clone()));
+            parser.check_sort_eq(&expected, sorts.last().unwrap())?;
+            Ok(None)
+        }
+        Operator::RelTclosure => {
+            assert_num_args(sorts, 1)?;
+            check_relation_sort(&sorts[0])?;
+            let Sort::Set(tuple) = sorts[0].as_ref() else {
+                unreachable!()
+            };
+            let Sort::Tuple(elems) = tuple.as_ref() else {
+                unreachable!()
+            };
+            if elems.len() != 2 {
+                // Hacky way to print an error saying the relation should be binary
+                let any = parser.pool.add_sort(Sort::Var("?".into()));
+                let tuple = parser.pool.add_sort(Sort::Tuple(vec![any.clone(), any]));
+                let expected = vec![parser.pool.add_sort(Sort::Set(tuple))].into_boxed_slice();
+                return Err(SortError { expected, got: sorts[0].clone() }.into());
+            }
+            Ok(None)
+        }
+        Operator::BvIte => {
+            assert_num_args(sorts, 3)?;
+            parser.check_sort_eq(&Sort::BitVec(1), &sorts[0])?;
+            parser.check_sort_all_eq(&sorts[1..])?;
+            Ok(None)
+        }
+        Operator::Custom(custom) => {
+            let def = custom.0;
+            assert_num_args(sorts, def.arg_sorts.len())?;
+            for (expected, got) in def.arg_sorts.iter().zip(sorts) {
+                parser.check_sort_eq(expected, got)?;
+            }
+            Ok(None)
+        }
+        op => unreachable!("operator {op:?} does not have custom type-checking logic"),
+    }
+}
+
+/// Type checks the arguments of an operator term, returning a replacement term if the operator
+/// builds one, or `None` if the caller should build the default `Term::Op(op, args)`.
+pub(super) fn check_op_types(
+    parser: &mut Parser,
+    op: Operator,
+    args: &[Rc<Term>],
+    sorts: &[Rc<Sort>],
+) -> Result<Option<Rc<Term>>, ParserError> {
+    match op_check(op, parser.config.allow_int_real_subtyping) {
+        OpCheck::Rule(rule) => {
+            rule.check(parser, sorts)?;
+            Ok(None)
+        }
+        OpCheck::Custom => custom_check(parser, op, args, sorts),
+    }
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -814,6 +814,35 @@ fn test_qualified_operators() {
 }
 
 #[test]
+fn test_custom_operators() {
+    let mut p = PrimitivePool::new();
+    let term = parse_term(&mut p, "(str.rev \"abc\")");
+    assert_eq!(p.sort(&term).as_ref(), &Sort::String);
+
+    let term = parse_term(&mut p, "(str.to_lower \"abc\")");
+    assert_eq!(p.sort(&term).as_ref(), &Sort::String);
+
+    let term = parse_term(&mut p, "(str.to_upper \"abc\")");
+    assert_eq!(p.sort(&term).as_ref(), &Sort::String);
+
+    let term = parse_term(&mut p, "(str.update \"abc\" 1 \"x\")");
+    assert_eq!(p.sort(&term).as_ref(), &Sort::String);
+
+    assert!(matches!(
+        parse_term_err("(str.rev 1)"),
+        Error::Parser(ParserError::SortError(_), _, _),
+    ));
+    assert!(matches!(
+        parse_term_err("(str.update \"abc\" \"1\" \"x\")"),
+        Error::Parser(ParserError::SortError(_), _, _),
+    ));
+    assert!(matches!(
+        parse_term_err("(str.update \"abc\" 1)"),
+        Error::Parser(ParserError::WrongNumberOfArgs(_, _), _, _),
+    ));
+}
+
+#[test]
 fn test_proofs_with_extra_parens() {
     let mut p = PrimitivePool::new();
     let proof = parse_proof(&mut p, "( (assume h1 true) )");


### PR DESCRIPTION
### Deferred operator type-checking rules (#91)

Splits the monolithic type-checking `match` in `Parser::make_op` into `src/parser/operators.rs`,
and adds an opt-in TOML config file (`custom_operators.toml`, read at compile time by `build.rs`)
for declaring new operators without touching Rust.

**What changed:**
- `operators.rs`: a small declarative rule DSL (arity + arg-sort constraints) replaces the
  ~400-line hand-written match for the ~150 built-in operators. Only ~10 operators (dynamic/
  config-dependent behavior, e.g. `RealDiv` literal folding, `Select`/`Store`, `ReFromAutomaton`)
  still need hand-written logic; everything else is a one-line rule.
- `Operator::Custom(CustomOperator)`: a new variant for operators declared in
  `custom_operators.toml` (`name` / `return_type` / `arg_types`). `build.rs` parses the file and
  codegens a static table; unknown sorts, duplicate names, or malformed entries fail the build.
- Shipped with 4 real cvc5 string extensions (`str.rev`, `str.to_lower`, `str.to_upper`,
  `str.update`) that carcara didn't implement as built-ins, as a working example.

**Open questions for discussion:**
- The TOML schema only supports the 5 primitive sorts (`Bool`/`Int`/`Real`/`String`/`RegLan`) -
  no `BitVec`/`Array`/`Set`/`Tuple`, since those need extra parameters or recursion. Worth it to
  extend, or keep custom operators intentionally simple?
- Custom operators are purely uninterpreted (no evaluation/rewrite semantics, no checker rules
  reference them) - is that the right ceiling for this feature, or should there be a path to give
  them real semantics later?
- `custom_operators.toml` lives at the repo root and is baked in at compile time (not runtime-
  configurable per invocation). Is compile-time the right granularity, or should downstream users
  be able to point at their own file without forking?
- No general TOML parser was added as a dependency - `build.rs` hand-parses this restricted
  schema. Fine for now, but would block extending the schema much further.
